### PR TITLE
Atomic refcounters, fixed device release

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -36,13 +36,14 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::QueryInterface(REFIID riid, void **pp
 }
 ULONG STDMETHODCALLTYPE Direct3DDevice8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DDevice8::Release()
 {
-	if (--_ref <= 2)
+	ULONG myRef = InterlockedDecrement(&_ref);
+	if (myRef <= 2)
 	{
 		if (_current_rendertarget != nullptr)
 		{
@@ -58,7 +59,7 @@ ULONG STDMETHODCALLTYPE Direct3DDevice8::Release()
 
 	const auto ref = _proxy->Release();
 
-	if (_ref == 0 && ref != 0)
+	if (myRef == 0 && ref != 0)
 	{
 		LOG << "Reference count for 'IDirect3DDevice8' object " << this << " (" << ref << ") is inconsistent." << std::endl;
 	}

--- a/source/d3d8to9_index_buffer.cpp
+++ b/source/d3d8to9_index_buffer.cpp
@@ -28,15 +28,16 @@ HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::QueryInterface(REFIID riid, void
 }
 ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}

--- a/source/d3d8to9_surface.cpp
+++ b/source/d3d8to9_surface.cpp
@@ -27,15 +27,16 @@ HRESULT STDMETHODCALLTYPE Direct3DSurface8::QueryInterface(REFIID riid, void **p
 }
 ULONG STDMETHODCALLTYPE Direct3DSurface8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DSurface8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}

--- a/source/d3d8to9_texture.cpp
+++ b/source/d3d8to9_texture.cpp
@@ -29,15 +29,16 @@ HRESULT STDMETHODCALLTYPE Direct3DTexture8::QueryInterface(REFIID riid, void **p
 }
 ULONG STDMETHODCALLTYPE Direct3DTexture8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DTexture8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}
@@ -176,15 +177,16 @@ HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::QueryInterface(REFIID riid, void
 }
 ULONG STDMETHODCALLTYPE Direct3DCubeTexture8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DCubeTexture8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}
@@ -323,15 +325,16 @@ HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::QueryInterface(REFIID riid, vo
 }
 ULONG STDMETHODCALLTYPE Direct3DVolumeTexture8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DVolumeTexture8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}

--- a/source/d3d8to9_vertex_buffer.cpp
+++ b/source/d3d8to9_vertex_buffer.cpp
@@ -28,15 +28,16 @@ HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::QueryInterface(REFIID riid, voi
 }
 ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}

--- a/source/d3d8to9_volume.cpp
+++ b/source/d3d8to9_volume.cpp
@@ -27,15 +27,16 @@ HRESULT STDMETHODCALLTYPE Direct3DVolume8::QueryInterface(REFIID riid, void **pp
 }
 ULONG STDMETHODCALLTYPE Direct3DVolume8::AddRef()
 {
-	_ref++;
+	InterlockedIncrement(&_ref);
 
 	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DVolume8::Release()
 {
 	const auto ref = _proxy->Release();
+	ULONG myRef = InterlockedDecrement(&_ref);
 
-	if (--_ref == 0)
+	if (myRef == 0)
 	{
 		delete this;
 	}


### PR DESCRIPTION
It could solve issues with inconsistent device refcounters in games which expect d3d8 to be thread safe.