### PR TITLE
Fix Clang compilation

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -20,7 +20,7 @@ class __declspec(uuid("BD7349F5-14F1-42E4-9C79-972380DB40C0")) Direct3DVolume8;
 class __declspec(uuid("8AEEEAC7-05F9-44D4-B591-000B0DF1CB95")) Direct3DVertexBuffer8;
 class __declspec(uuid("0E689C9A-053D-44A0-9D92-DB0E3D750F86")) Direct3DIndexBuffer8;
 
-class Direct3D8 : IUnknown
+class Direct3D8 : public IUnknown
 {
 	Direct3D8(const Direct3D8 &) = delete;
 	Direct3D8 &operator=(const Direct3D8 &) = delete;
@@ -53,7 +53,7 @@ public:
 private:
 	IDirect3D9 *const _proxy;
 };
-class Direct3DDevice8 : IUnknown
+class Direct3DDevice8 : public IUnknown
 {
 	Direct3DDevice8(const Direct3DDevice8 &) = delete;
 	Direct3DDevice8 &operator=(const Direct3DDevice8 &) = delete;
@@ -178,7 +178,7 @@ private:
 	DWORD _current_vertex_shader = 0, _current_pixel_shader = 0;
 	Direct3DSurface8 *_current_rendertarget = nullptr, *_current_depthstencil = nullptr;
 };
-class Direct3DSwapChain8 : IUnknown
+class Direct3DSwapChain8 : public IUnknown
 {
 	Direct3DSwapChain8(const Direct3DSwapChain8 &) = delete;
 	Direct3DSwapChain8 &operator=(const Direct3DSwapChain8 &) = delete;
@@ -206,7 +206,7 @@ private:
 	Direct3DDevice8 *const _device;
 	IDirect3DSwapChain9 *const _proxy;
 };
-class Direct3DResource8 : IUnknown
+class Direct3DResource8 : public IUnknown
 {
 public:
 	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) = 0;
@@ -360,7 +360,7 @@ private:
 	Direct3DDevice8 *const _device;
 	IDirect3DVolumeTexture9 *const _proxy;
 };
-class Direct3DSurface8 : IUnknown
+class Direct3DSurface8 : public IUnknown
 {
 	Direct3DSurface8(const Direct3DSurface8 &) = delete;
 	Direct3DSurface8 &operator=(const Direct3DSurface8 &) = delete;
@@ -395,7 +395,7 @@ private:
 	Direct3DDevice8 *const _device;
 	IDirect3DSurface9 *const _proxy;
 };
-class Direct3DVolume8 : IUnknown
+class Direct3DVolume8 : public IUnknown
 {
 	Direct3DVolume8(const Direct3DVolume8 &) = delete;
 	Direct3DVolume8 &operator=(const Direct3DVolume8 &) = delete;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -904,6 +904,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, Direct3DBaseT
 				basetexture->QueryInterface(IID_PPV_ARGS(&cubetexture));
 				*ppTexture = new Direct3DCubeTexture8(this, cubetexture);
 				break;
+			default:
+				basetexture->Release();
+				return D3DERR_INVALIDCALL;
 		}
 
 		basetexture->Release();

--- a/source/d3d8types.hpp
+++ b/source/d3d8types.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+struct IUnknown;
 #include <d3d9.h>
 
 #define D3DFMT_W11V11U10 65


### PR DESCRIPTION
Compiling with v140 toolsets in /MT mode (I don't want to rely on VS2015 redist packages) gives me a RIDICULOUS amount of hits on virustotal:

https://www.virustotal.com/file/ecd4935c5a3b653062a648674c6856cbd47edd33e6f5c7e64a4277054ec261c9/analysis/1480277016/

The issue seems to be real since within 24h from the moment the update with this DLL went live I saw numerous people reporting their AVs block the game...

Oddly enough, if I remove file logging OR switch to Clang, all those hits are gone. MS's Clang requires some slight changes to the code though, so there it is. v140 still compiles fine, of couse.