### PR TITLE
Update to fix graphic issues with Haegemonia and enhance compatibility

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -189,9 +189,6 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	const auto device_proxy = new Direct3DDevice8(this, device, (pp.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
-	// Set default vertex declaration
-	device->SetFVF(D3DFVF_XYZ);
-
 	// Set default render target
 	IDirect3DSurface9 *rendertarget = nullptr, *depthstencil = nullptr;
 	Direct3DSurface8 *rendertarget_proxy = nullptr, *depthstencil_proxy = nullptr;

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -69,11 +69,11 @@ void convert_caps(D3DCAPS9 &input, D3DCAPS8 &output)
 {
 	CopyMemory(&output, &input, sizeof(output));
 
-	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;								// Tell application that windows mode is supported
+	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;								// Tell application that window mode is supported
 	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;								// Tell application that z-bias is supported
 	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;							// Remove unsupported StencilCaps type
-	output.PixelShaderVersion = D3DPS_VERSION(1, 4);						// Set defaul PixelShaderVersion to 1.4 for D3D8 compatibility
-	output.VertexShaderVersion = D3DVS_VERSION(1, 1);						// Set defaul VertexShaderVersion to 1.1 for D3D8 compatibility
+	output.PixelShaderVersion = D3DPS_VERSION(1, 4);						// Set default PixelShaderVersion to 1.4 for D3D8 compatibility
+	output.VertexShaderVersion = D3DVS_VERSION(1, 1);						// Set default VertexShaderVersion to 1.1 for D3D8 compatibility
 	output.MaxVertexShaderConst = min(256, input.MaxVertexShaderConst);		// D3D8 can only handle upto 256 for MaxVertexShaderConst
 }
 void convert_volume_desc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output)
@@ -94,17 +94,14 @@ void convert_surface_desc(D3DSURFACE_DESC &input, D3DSURFACE_DESC8 &output)
 	output.Usage = input.Usage;
 	output.Pool = input.Pool;
 	output.Size = calc_texture_size(input.Width, input.Height, 1, input.Format);
+	output.MultiSampleType = input.MultiSampleType;
 	output.Width = input.Width;
 	output.Height = input.Height;
 
 	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
-	if (input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	if (output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
 	{
 		output.MultiSampleType = D3DMULTISAMPLE_NONE;
-	}
-	else
-	{
-		output.MultiSampleType = input.MultiSampleType;
 	}
 }
 void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAMETERS &output)
@@ -113,46 +110,38 @@ void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAME
 	output.BackBufferHeight = input.BackBufferHeight;
 	output.BackBufferFormat = input.BackBufferFormat;
 	output.BackBufferCount = input.BackBufferCount;
+	output.MultiSampleType = input.MultiSampleType;
 	output.MultiSampleQuality = 0;
+	output.SwapEffect = input.SwapEffect;
 	output.hDeviceWindow = input.hDeviceWindow;
 	output.Windowed = input.Windowed;
 	output.EnableAutoDepthStencil = input.EnableAutoDepthStencil;
 	output.AutoDepthStencilFormat = input.AutoDepthStencilFormat;
 	output.Flags = input.Flags;
 	output.FullScreen_RefreshRateInHz = input.FullScreen_RefreshRateInHz;
+	output.PresentationInterval = input.FullScreen_PresentationInterval;
 
 	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD.
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172588(v=vs.85).aspx
 	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
-	if (input.SwapEffect != D3DSWAPEFFECT_DISCARD || input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	if (output.SwapEffect != D3DSWAPEFFECT_DISCARD || output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
 	{
 		output.MultiSampleType = D3DMULTISAMPLE_NONE;
-	}
-	else
-	{
-		output.MultiSampleType = input.MultiSampleType;
 	}
 
 	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
 	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
 	// application is not windowed for best D3D8 compatibility
-	if (input.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED || (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !input.Windowed))
+	if (output.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED ||
+		(output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !output.Windowed))
 	{
 		output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
 	}
-	else
-	{
-		output.PresentationInterval = input.FullScreen_PresentationInterval;
-	}
 
 	// D3DSWAPEFFECT_COPY_VSYNC is no longer supported in D3D9
-	if (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
+	if (output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
 	{
 		output.SwapEffect = D3DSWAPEFFECT_COPY;
-	}
-	else
-	{
-		output.SwapEffect = input.SwapEffect;
 	}
 }
 void convert_adapter_identifier(D3DADAPTER_IDENTIFIER9 &input, D3DADAPTER_IDENTIFIER8 &output)

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -1,6 +1,8 @@
 /**
  * Copyright (C) 2015 Patrick Mours. All rights reserved.
  * License: https://github.com/crosire/d3d8to9#license
+ *
+ * Updated 2017 by Elisha Riedlinger
  */
 
 #include "d3d8types.hpp"
@@ -69,16 +71,12 @@ void convert_caps(D3DCAPS9 &input, D3DCAPS8 &output)
 {
 	CopyMemory(&output, &input, sizeof(output));
 
-	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;
-	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;
-	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;
-	output.VertexShaderVersion = D3DVS_VERSION(1, 1);
-	output.PixelShaderVersion = D3DPS_VERSION(1, 4);
-
-	if (output.MaxVertexShaderConst > 256)
-	{
-		output.MaxVertexShaderConst = 256;
-	}
+	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;								// Tell application that windows mode is supported
+	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;								// Tell application that z-bias is supported
+	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;							// Remove unsupported StencilCaps type
+	output.PixelShaderVersion = D3DPS_VERSION(1, 4);						// Set defaul PixelShaderVersion to 1.4 for D3D8 compatibility
+	output.VertexShaderVersion = D3DVS_VERSION(1, 1);						// Set defaul VertexShaderVersion to 1.1 for D3D8 compatibility
+	output.MaxVertexShaderConst = min(256, input.MaxVertexShaderConst);		// D3D8 can only handle upto 256 for MaxVertexShaderConst
 }
 void convert_volume_desc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output)
 {
@@ -98,13 +96,17 @@ void convert_surface_desc(D3DSURFACE_DESC &input, D3DSURFACE_DESC8 &output)
 	output.Usage = input.Usage;
 	output.Pool = input.Pool;
 	output.Size = calc_texture_size(input.Width, input.Height, 1, input.Format);
-	output.MultiSampleType = input.MultiSampleType;
 	output.Width = input.Width;
 	output.Height = input.Height;
 
-	if (output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
+	if (input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
 	{
 		output.MultiSampleType = D3DMULTISAMPLE_NONE;
+	}
+	else
+	{
+		output.MultiSampleType = input.MultiSampleType;
 	}
 }
 void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAMETERS &output)
@@ -113,25 +115,46 @@ void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAME
 	output.BackBufferHeight = input.BackBufferHeight;
 	output.BackBufferFormat = input.BackBufferFormat;
 	output.BackBufferCount = input.BackBufferCount;
-	output.MultiSampleType = input.MultiSampleType;
 	output.MultiSampleQuality = 0;
-	output.SwapEffect = input.SwapEffect;
 	output.hDeviceWindow = input.hDeviceWindow;
 	output.Windowed = input.Windowed;
 	output.EnableAutoDepthStencil = input.EnableAutoDepthStencil;
 	output.AutoDepthStencilFormat = input.AutoDepthStencilFormat;
 	output.Flags = input.Flags;
 	output.FullScreen_RefreshRateInHz = input.FullScreen_RefreshRateInHz;
-	output.PresentationInterval = input.FullScreen_PresentationInterval;
 
-	if (output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
+	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172588(v=vs.85).aspx
+	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
+	if (input.SwapEffect != D3DSWAPEFFECT_DISCARD || input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	{
+		output.MultiSampleType = D3DMULTISAMPLE_NONE;
+	}
+	else
+	{
+		output.MultiSampleType = input.MultiSampleType;
+	}
+
+	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
+	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
+	// application is not windowed for best D3D8 compatibility
+	if (input.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED || (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !input.Windowed))
+	{
+		output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
+	}
+	else
+	{
+		output.PresentationInterval = input.FullScreen_PresentationInterval;
+	}
+
+	// D3DSWAPEFFECT_COPY_VSYNC is no longer supported in D3D9
+	if (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
 	{
 		output.SwapEffect = D3DSWAPEFFECT_COPY;
 	}
-
-	if (output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED)
+	else
 	{
-		output.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+		output.SwapEffect = input.SwapEffect;
 	}
 }
 void convert_adapter_identifier(D3DADAPTER_IDENTIFIER9 &input, D3DADAPTER_IDENTIFIER8 &output)

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -1,8 +1,6 @@
 /**
  * Copyright (C) 2015 Patrick Mours. All rights reserved.
  * License: https://github.com/crosire/d3d8to9#license
- *
- * Updated 2017 by Elisha Riedlinger
  */
 
 #include "d3d8types.hpp"
@@ -71,12 +69,16 @@ void convert_caps(D3DCAPS9 &input, D3DCAPS8 &output)
 {
 	CopyMemory(&output, &input, sizeof(output));
 
-	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;								// Tell application that windows mode is supported
-	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;								// Tell application that z-bias is supported
-	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;							// Remove unsupported StencilCaps type
-	output.PixelShaderVersion = D3DPS_VERSION(1, 4);						// Set defaul PixelShaderVersion to 1.4 for D3D8 compatibility
-	output.VertexShaderVersion = D3DVS_VERSION(1, 1);						// Set defaul VertexShaderVersion to 1.1 for D3D8 compatibility
-	output.MaxVertexShaderConst = min(256, input.MaxVertexShaderConst);		// D3D8 can only handle upto 256 for MaxVertexShaderConst
+	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;
+	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;
+	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;
+	output.VertexShaderVersion = D3DVS_VERSION(1, 1);
+	output.PixelShaderVersion = D3DPS_VERSION(1, 4);
+
+	if (output.MaxVertexShaderConst > 256)
+	{
+		output.MaxVertexShaderConst = 256;
+	}
 }
 void convert_volume_desc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output)
 {
@@ -96,17 +98,13 @@ void convert_surface_desc(D3DSURFACE_DESC &input, D3DSURFACE_DESC8 &output)
 	output.Usage = input.Usage;
 	output.Pool = input.Pool;
 	output.Size = calc_texture_size(input.Width, input.Height, 1, input.Format);
+	output.MultiSampleType = input.MultiSampleType;
 	output.Width = input.Width;
 	output.Height = input.Height;
 
-	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
-	if (input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	if (output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
 	{
 		output.MultiSampleType = D3DMULTISAMPLE_NONE;
-	}
-	else
-	{
-		output.MultiSampleType = input.MultiSampleType;
 	}
 }
 void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAMETERS &output)
@@ -115,46 +113,25 @@ void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAME
 	output.BackBufferHeight = input.BackBufferHeight;
 	output.BackBufferFormat = input.BackBufferFormat;
 	output.BackBufferCount = input.BackBufferCount;
+	output.MultiSampleType = input.MultiSampleType;
 	output.MultiSampleQuality = 0;
+	output.SwapEffect = input.SwapEffect;
 	output.hDeviceWindow = input.hDeviceWindow;
 	output.Windowed = input.Windowed;
 	output.EnableAutoDepthStencil = input.EnableAutoDepthStencil;
 	output.AutoDepthStencilFormat = input.AutoDepthStencilFormat;
 	output.Flags = input.Flags;
 	output.FullScreen_RefreshRateInHz = input.FullScreen_RefreshRateInHz;
+	output.PresentationInterval = input.FullScreen_PresentationInterval;
 
-	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD.
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172588(v=vs.85).aspx
-	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
-	if (input.SwapEffect != D3DSWAPEFFECT_DISCARD || input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
-	{
-		output.MultiSampleType = D3DMULTISAMPLE_NONE;
-	}
-	else
-	{
-		output.MultiSampleType = input.MultiSampleType;
-	}
-
-	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
-	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
-	// application is not windowed for best D3D8 compatibility
-	if (input.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED || (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !input.Windowed))
-	{
-		output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
-	}
-	else
-	{
-		output.PresentationInterval = input.FullScreen_PresentationInterval;
-	}
-
-	// D3DSWAPEFFECT_COPY_VSYNC is no longer supported in D3D9
-	if (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
+	if (output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
 	{
 		output.SwapEffect = D3DSWAPEFFECT_COPY;
 	}
-	else
+
+	if (output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED)
 	{
-		output.SwapEffect = input.SwapEffect;
+		output.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
 	}
 }
 void convert_adapter_identifier(D3DADAPTER_IDENTIFIER9 &input, D3DADAPTER_IDENTIFIER8 &output)

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -132,7 +132,7 @@ void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAME
 	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
 	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
 	// application is not windowed for best D3D8 compatibility
-	if (output.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED ||
+	if (output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED ||
 		(output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !output.Windowed))
 	{
 		output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -69,16 +69,12 @@ void convert_caps(D3DCAPS9 &input, D3DCAPS8 &output)
 {
 	CopyMemory(&output, &input, sizeof(output));
 
-	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;
-	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;
-	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;
-	output.VertexShaderVersion = D3DVS_VERSION(1, 1);
-	output.PixelShaderVersion = D3DPS_VERSION(1, 4);
-
-	if (output.MaxVertexShaderConst > 256)
-	{
-		output.MaxVertexShaderConst = 256;
-	}
+	output.Caps2 |= D3DCAPS2_CANRENDERWINDOWED;								// Tell application that windows mode is supported
+	output.RasterCaps |= D3DPRASTERCAPS_ZBIAS;								// Tell application that z-bias is supported
+	output.StencilCaps &= ~D3DSTENCILCAPS_TWOSIDED;							// Remove unsupported StencilCaps type
+	output.PixelShaderVersion = D3DPS_VERSION(1, 4);						// Set defaul PixelShaderVersion to 1.4 for D3D8 compatibility
+	output.VertexShaderVersion = D3DVS_VERSION(1, 1);						// Set defaul VertexShaderVersion to 1.1 for D3D8 compatibility
+	output.MaxVertexShaderConst = min(256, input.MaxVertexShaderConst);		// D3D8 can only handle upto 256 for MaxVertexShaderConst
 }
 void convert_volume_desc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output)
 {
@@ -98,13 +94,17 @@ void convert_surface_desc(D3DSURFACE_DESC &input, D3DSURFACE_DESC8 &output)
 	output.Usage = input.Usage;
 	output.Pool = input.Pool;
 	output.Size = calc_texture_size(input.Width, input.Height, 1, input.Format);
-	output.MultiSampleType = input.MultiSampleType;
 	output.Width = input.Width;
 	output.Height = input.Height;
 
-	if (output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
+	if (input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
 	{
 		output.MultiSampleType = D3DMULTISAMPLE_NONE;
+	}
+	else
+	{
+		output.MultiSampleType = input.MultiSampleType;
 	}
 }
 void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAMETERS &output)
@@ -113,25 +113,46 @@ void convert_present_parameters(D3DPRESENT_PARAMETERS8 &input, D3DPRESENT_PARAME
 	output.BackBufferHeight = input.BackBufferHeight;
 	output.BackBufferFormat = input.BackBufferFormat;
 	output.BackBufferCount = input.BackBufferCount;
-	output.MultiSampleType = input.MultiSampleType;
 	output.MultiSampleQuality = 0;
-	output.SwapEffect = input.SwapEffect;
 	output.hDeviceWindow = input.hDeviceWindow;
 	output.Windowed = input.Windowed;
 	output.EnableAutoDepthStencil = input.EnableAutoDepthStencil;
 	output.AutoDepthStencilFormat = input.AutoDepthStencilFormat;
 	output.Flags = input.Flags;
 	output.FullScreen_RefreshRateInHz = input.FullScreen_RefreshRateInHz;
-	output.PresentationInterval = input.FullScreen_PresentationInterval;
 
-	if (output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
+	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172588(v=vs.85).aspx
+	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
+	if (input.SwapEffect != D3DSWAPEFFECT_DISCARD || input.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	{
+		output.MultiSampleType = D3DMULTISAMPLE_NONE;
+	}
+	else
+	{
+		output.MultiSampleType = input.MultiSampleType;
+	}
+
+	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
+	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
+	// application is not windowed for best D3D8 compatibility
+	if (input.FullScreen_PresentationInterval == D3DPRESENT_RATE_UNLIMITED || (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !input.Windowed))
+	{
+		output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
+	}
+	else
+	{
+		output.PresentationInterval = input.FullScreen_PresentationInterval;
+	}
+
+	// D3DSWAPEFFECT_COPY_VSYNC is no longer supported in D3D9
+	if (input.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
 	{
 		output.SwapEffect = D3DSWAPEFFECT_COPY;
 	}
-
-	if (output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED)
+	else
 	{
-		output.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+		output.SwapEffect = input.SwapEffect;
 	}
 }
 void convert_adapter_identifier(D3DADAPTER_IDENTIFIER9 &input, D3DADAPTER_IDENTIFIER8 &output)


### PR DESCRIPTION
 - Removed "device->SetFVF(D3DFVF_XYZ);" line from Direct3D8::CreateDevice.  This fixes an issue with game Haegemonia Legions of Iron.  It seems there is no need to declare a default vertex here.   According to Microsoft documentation D3D8 applications should  call SetVertexShader API before using a vertex and SetFVF  already called when an application calls SetVertexShader.  https://msdn.microsoft.com/en-us/library/windows/desktop/bb204851(v=vs.85).aspx#Vertex_Declaration_Changes
 - Minor updates to convert_caps and convert_surface_desc to simplify code.
 - Updates to convert_present_parameters for better d3d9 copmatibility.
 - Updated logic for when MultiSampleType should be set to D3DMULTISAMPLE_NONE.
 - Changed PresentationInterval to default to D3DPRESENT_INTERVAL_ONE, the normal d3d9 default and makes more copmatible with d3d9 when D3DSWAPEFFECT_COPY_VSYNC was used.  According to Microsoft D3DPRESENT_INTERVAL_IMMEDIATE did nothing in fullscreen on d3d8 when D3DSWAPEFFECT_COPY_VSYNC was used.  So this is attempting to replicate that behavor.
 - Minor updates to the code slightly for when SwapEffect is set to D3DSWAPEFFECT_COPY.
 - Added some documentation to the code