### PR TITLE
Make d3dx9_xx.dll load dynamically

### DIFF
--- a/d3d8to9.vcxproj
+++ b/d3d8to9.vcxproj
@@ -48,7 +48,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>res\d3d8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>d3d9.lib;d3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d9.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <d3dx9shader.h>
 
-// D3DXLoadSurfaceFromSurface declaration for d3dx9_xx.dll
+// D3DXLoadSurfaceFromSurface declaration for d3dx9_43.dll
 typedef HRESULT(__stdcall *D3DXLoadSurfaceFromSurfaceType)(
 	_In_       LPDIRECT3DSURFACE9 pDestSurface,
 	_In_ const PALETTEENTRY       *pDestPalette,
@@ -21,7 +21,7 @@ typedef HRESULT(__stdcall *D3DXLoadSurfaceFromSurfaceType)(
 	);
 D3DXLoadSurfaceFromSurfaceType D3DXLoadSurfaceFromSurfacePtr = nullptr;
 
-// D3DXAssembleShader declaration for d3dx9_xx.dll
+// D3DXAssembleShader declaration for d3dx9_43.dll
 typedef HRESULT(__stdcall *D3DXAssembleShaderType)(
 	_In_        LPCSTR        pSrcData,
 	_In_        UINT          SrcDataLen,
@@ -33,7 +33,7 @@ typedef HRESULT(__stdcall *D3DXAssembleShaderType)(
 	);
 D3DXAssembleShaderType D3DXAssembleShaderPtr = nullptr;
 
-// D3DXDisassembleShader declaration for d3dx9_xx.dll
+// D3DXDisassembleShader declaration for d3dx9_43.dll
 typedef HRESULT(__stdcall *D3DXDisassembleShaderType)(
 	_In_  const DWORD        *pShader,
 	_In_        BOOL         EnableColorCode,
@@ -53,8 +53,7 @@ bool LoadD3dx9()
 	else
 	{
 		// Load dll
-		HMODULE dllHandle = NULL;
-		dllHandle = LoadLibrary("d3dx9_43.dll");
+		HMODULE dllHandle = LoadLibrary(TEXT("d3dx9_43.dll"));
 
 		// Cannot load dll
 		if (dllHandle == NULL)

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -52,29 +52,15 @@ bool LoadD3dx9()
 	}
 	else
 	{
-		// Declare vars
+		// Load dll
 		HMODULE dllHandle = NULL;
-		char d3dx9name[MAX_PATH];
-
-		// Check for different versions of d3dx9_xx.dll
-		for (int x = 99; x > 9 && dllHandle == NULL; x--)
-		{
-			// Get dll name
-			strcpy_s(d3dx9name, "d3dx9_");
-			char buffer[11];
-			_itoa_s(x, buffer, 10);
-			strcat_s(d3dx9name, buffer);
-			strcat_s(d3dx9name, ".dll");
-
-			// Load dll
-			dllHandle = LoadLibrary(d3dx9name);
-		}
+		dllHandle = LoadLibrary("d3dx9_43.dll");
 
 		// Cannot load dll
 		if (dllHandle == NULL)
 		{
 #ifndef D3D8TO9NOLOG
-			LOG << "Failed to load d3dx9_xx.dll!" << std::endl;
+			LOG << "Failed to load d3dx9_43.dll!" << std::endl;
 #endif
 			return false;
 		}
@@ -83,7 +69,7 @@ bool LoadD3dx9()
 		{
 			IsD3dx9Loaded = true;
 #ifndef D3D8TO9NOLOG
-			LOG << "Loaded " << d3dx9name << std::endl;
+			LOG << "Loaded d3dx9_43.dll" << std::endl;
 #endif
 
 			// Get pointers to each function


### PR DESCRIPTION
d3dx8_43.dll was loaded statically before.  Some systems have different versions of this dll.  Changed it to load dynamically based on the version available on the system.

Note: This is also done by other programs.  Check out the log from ts3overlay [here](https://pastebin.com/s8RWZExL).