### PR TITLE
Alternate refcounting method

### DIFF
--- a/d3d8to9.vcxproj
+++ b/d3d8to9.vcxproj
@@ -18,14 +18,14 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">

--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -22,7 +22,7 @@ extern "C" Direct3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
 
 	if (!LOG.is_open())
 	{
-		MessageBoxA(nullptr, "Failed to open debug log file \"d3d8.log\"!", nullptr, MB_ICONWARNING);
+		MessageBox(nullptr, TEXT("Failed to open debug log file \"d3d8.log\"!"), nullptr, MB_ICONWARNING);
 	}
 
 	LOG << "Redirecting '" << "Direct3DCreate8" << "(" << SDKVersion << ")' ..." << std::endl;

--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -65,6 +65,7 @@ public:
 	}
 	~Direct3DDevice8()
 	{
+		_proxy->Release();
 		_d3d->Release();
 	}
 
@@ -237,6 +238,7 @@ public:
 	}
 	~Direct3DTexture8()
 	{
+		_proxy->Release();
 		_device->Release();
 	}
 
@@ -372,6 +374,7 @@ public:
 	}
 	~Direct3DSurface8()
 	{
+		_proxy->Release();
 		_device->Release();
 	}
 
@@ -407,6 +410,7 @@ public:
 	}
 	~Direct3DVolume8()
 	{
+		_proxy->Release();
 		_device->Release();
 	}
 
@@ -442,6 +446,7 @@ public:
 	}
 	~Direct3DVertexBuffer8()
 	{
+		_proxy->Release();
 		_device->Release();
 	}
 
@@ -481,6 +486,7 @@ public:
 	}
 	~Direct3DIndexBuffer8()
 	{
+		_proxy->Release();
 		_device->Release();
 	}
 

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -36,9 +36,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::QueryInterface(REFIID riid, void **pp
 }
 ULONG STDMETHODCALLTYPE Direct3DDevice8::AddRef()
 {
-	InterlockedIncrement(&_ref);
-
-	return _proxy->AddRef();
+	return InterlockedIncrement(&_ref);
 }
 ULONG STDMETHODCALLTYPE Direct3DDevice8::Release()
 {
@@ -64,22 +62,14 @@ ULONG STDMETHODCALLTYPE Direct3DDevice8::Release()
 		ds->Release();
 	}
 
-	const auto ref = _proxy->Release();
 	myRef = InterlockedDecrement(&_ref);
-
-	if (myRef == 0 && ref != 0)
-	{
-#ifndef D3D8TO9NOLOG
-		LOG << "Reference count for 'IDirect3DDevice8' object " << this << " (" << ref << ") is inconsistent." << std::endl;
-#endif
-	}
 
 	if (myRef == 0)
 	{
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::TestCooperativeLevel()
 {

--- a/source/d3d8to9_index_buffer.cpp
+++ b/source/d3d8to9_index_buffer.cpp
@@ -28,13 +28,10 @@ HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::QueryInterface(REFIID riid, void
 }
 ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::AddRef()
 {
-	InterlockedIncrement(&_ref);
-
-	return _proxy->AddRef();
+	return InterlockedIncrement(&_ref);
 }
 ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::Release()
 {
-	const auto ref = _proxy->Release();
 	ULONG myRef = InterlockedDecrement(&_ref);
 
 	if (myRef == 0)
@@ -42,7 +39,7 @@ ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::Release()
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)
 {

--- a/source/d3d8to9_surface.cpp
+++ b/source/d3d8to9_surface.cpp
@@ -27,13 +27,11 @@ HRESULT STDMETHODCALLTYPE Direct3DSurface8::QueryInterface(REFIID riid, void **p
 }
 ULONG STDMETHODCALLTYPE Direct3DSurface8::AddRef()
 {
-	InterlockedIncrement(&_ref);
+	return InterlockedIncrement(&_ref);
 
-	return _proxy->AddRef();
 }
 ULONG STDMETHODCALLTYPE Direct3DSurface8::Release()
 {
-	const auto ref = _proxy->Release();
 	ULONG myRef = InterlockedDecrement(&_ref);
 
 	if (myRef == 0)
@@ -41,7 +39,7 @@ ULONG STDMETHODCALLTYPE Direct3DSurface8::Release()
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DSurface8::GetDevice(Direct3DDevice8 **ppDevice)
 {

--- a/source/d3d8to9_texture.cpp
+++ b/source/d3d8to9_texture.cpp
@@ -29,13 +29,10 @@ HRESULT STDMETHODCALLTYPE Direct3DTexture8::QueryInterface(REFIID riid, void **p
 }
 ULONG STDMETHODCALLTYPE Direct3DTexture8::AddRef()
 {
-	InterlockedIncrement(&_ref);
-
-	return _proxy->AddRef();
+	return InterlockedIncrement(&_ref);
 }
 ULONG STDMETHODCALLTYPE Direct3DTexture8::Release()
 {
-	const auto ref = _proxy->Release();
 	ULONG myRef = InterlockedDecrement(&_ref);
 
 	if (myRef == 0)
@@ -43,7 +40,7 @@ ULONG STDMETHODCALLTYPE Direct3DTexture8::Release()
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetDevice(Direct3DDevice8 **ppDevice)
 {

--- a/source/d3d8to9_vertex_buffer.cpp
+++ b/source/d3d8to9_vertex_buffer.cpp
@@ -28,13 +28,10 @@ HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::QueryInterface(REFIID riid, voi
 }
 ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::AddRef()
 {
-	InterlockedIncrement(&_ref);
-
-	return _proxy->AddRef();
+	return InterlockedIncrement(&_ref);
 }
 ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::Release()
 {
-	const auto ref = _proxy->Release();
 	ULONG myRef = InterlockedDecrement(&_ref);
 
 	if (myRef == 0)
@@ -42,7 +39,7 @@ ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::Release()
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)
 {

--- a/source/d3d8to9_volume.cpp
+++ b/source/d3d8to9_volume.cpp
@@ -27,13 +27,10 @@ HRESULT STDMETHODCALLTYPE Direct3DVolume8::QueryInterface(REFIID riid, void **pp
 }
 ULONG STDMETHODCALLTYPE Direct3DVolume8::AddRef()
 {
-	InterlockedIncrement(&_ref);
-
-	return _proxy->AddRef();
+	return InterlockedIncrement(&_ref);
 }
 ULONG STDMETHODCALLTYPE Direct3DVolume8::Release()
 {
-	const auto ref = _proxy->Release();
 	ULONG myRef = InterlockedDecrement(&_ref);
 
 	if (myRef == 0)
@@ -41,7 +38,7 @@ ULONG STDMETHODCALLTYPE Direct3DVolume8::Release()
 		delete this;
 	}
 
-	return ref;
+	return myRef;
 }
 HRESULT STDMETHODCALLTYPE Direct3DVolume8::GetDevice(Direct3DDevice8 **ppDevice)
 {


### PR DESCRIPTION
With this change, underlying d3d9 resources don't have their refcounts changed by wrapper's `AddRef` and `Release` and instead they only get released once at wrapper destruction time. Instead of returning underlying resource's refcount from wrapper functions, now wrapper's refcounts are returned. This fixes cases where the game is doing something like

```c++
while(resource->Release() > 0);
```

Might also be a micro optimization since it issues less d3d calls (albeit refcount ones should be nearly no-ops).

Fixes #19 