### PR TITLE
Update pixel shader translations to fix lighting issues

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1388,7 +1388,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		SourceCode = std::regex_replace(SourceCode, std::regex("(oFog|oPts)\\.x"), "$1 /* removed swizzle */");
 		SourceCode = std::regex_replace(SourceCode, std::regex("(add|sub|mul|min|max) (oFog|oPts), ([cr][0-9]+), (.+)\\n"), "$1 $2, $3.x /* added swizzle */, $4\n");
 		SourceCode = std::regex_replace(SourceCode, std::regex("(add|sub|mul|min|max) (oFog|oPts), (.+), ([cr][0-9]+)\\n"), "$1 $2, $3, $4.x /* added swizzle */\n");
-		SourceCode = std::regex_replace(SourceCode, std::regex("mov (oFog|oPts)(.*), (-?)([crv][0-9]+(?![0-9])(?!\\.))"), "mov $1$2, $3$4.x /* select single component */");
+		SourceCode = std::regex_replace(SourceCode, std::regex("mov (oFog|oPts)(.*), (-?)([crv][0-9]+(?![\\.0-9]))"), "mov $1$2, $3$4.x /* select single component */");
 
 #ifndef D3D8TO9NOLOG
 		LOG << "> Dumping translated shader assembly:" << std::endl << std::endl << SourceCode << std::endl;
@@ -1729,10 +1729,47 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 		SourceCode.replace(VersionPosition, 6, "ps_1_1");
 	}
 
+	// Get number of arithmetic used max of 8 is allowed
+	int countArithmetic = 10;	// Default to 10
+	const size_t ArithmeticPosition = SourceCode.find("arithmetic");
+	if (ArithmeticPosition > 2 && ArithmeticPosition < SourceCode.size())
+	{
+		countArithmetic = atoi(&SourceCode[ArithmeticPosition - 2]);
+		if (countArithmetic == 0)
+		{
+			countArithmetic = 10;	// Default to 10
+		}
+	}
+
+	// Remove lines when "    // ps.1.1" string is found and the next line does not start with a space
 	SourceCode = std::regex_replace(SourceCode, std::regex("    \\/\\/ ps\\.1\\.[1-4]\\n((?! ).+\\n)+"), "");
-	SourceCode = std::regex_replace(SourceCode, std::regex("(c[0-9]+\\.?[wxyz]*)(_bx2|_bias|_x2|_d[zbwa])"), "$1 /* removed modifier $2 */");
-	SourceCode = std::regex_replace(SourceCode, std::regex("(add)([_satxd248]*) ([crtv][0-9]+[\\.]?[wxyz]*), ([crtv][0-9]+[\\.]?[wxyz]*), (-)(c[0-9]+(?![0-9])\\.?[wxyz]*(?![wxyz]))"), "sub$2 $3, $4, $6 /* changed 'add' to 'sub' removed modifier $5 */");
-	SourceCode = std::regex_replace(SourceCode, std::regex("(1?-)(c[0-9]+(?![0-9])\\.?[wxyz]*(?![wxyz]))"), "$2 /* removed modifier $1 */");
+
+	// Fix '-' modifier for constant values when using 'add' arithmetic by changing it to use 'sub'
+	SourceCode = std::regex_replace(SourceCode, std::regex("(add)([_satxd248]*) (r[0-9][\\.wxyz]*), ((1-|)[crtv][0-9][\\.wxyz_abdis2]*), (-)(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)(?![_\\.wxyz])"),
+		"sub$2 $3, $4, $7$8 /* changed 'add' to 'sub' removed modifier $6 */");
+	// Fix modifiers for constant values by using any remaning arithmetic places to add a 'mov' arithmetic to move the constant value to a temporary register
+	for (int x = 8 - countArithmetic; x > 0; x--)
+	{
+		const size_t beforeReplace = SourceCode.size();
+		// Only replace one match
+		SourceCode = std::regex_replace(SourceCode, std::regex("(...)(_[_satxd248]*|) (r[0-9][\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
+			"mov $3, $9$10$13$14 /* added line */\n    $1$2 $3, $4$5$8$12$3$10$11$14$15 /* changed $9$13 to $3 */", std::regex_constants::format_first_only);
+		// Check if string was replaced
+		if (SourceCode.size() - beforeReplace == 0)
+		{
+			break;
+		}
+	}
+	// Change '-' modifier for constant values when using 'mad' arithmetic by changing it to use 'sub'
+	SourceCode = std::regex_replace(SourceCode, std::regex("(mad)([_satxd248]*) (r[0-9][\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*), (-)(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)(?![_\\.wxyz])"),
+		"sub$2 $3, $4, $7$8 /* changed 'mad' to 'sub' removed $5 removed modifier $6 */");
+	// Change '_bx2' modifier for constant values to use _x2 modifier
+	SourceCode = std::regex_replace(SourceCode, std::regex("(...)(_sat|) (r[0-9][\\.wxyz]*), ([crtv][0-9][\\.wxyz]*)_bx2, (c[0-9][\\.wxyz]*)_bx2(?!,)"),
+		"$1_x2$2 $3, $4, $5 /* removed modifiers _bx2 added modifier _x2 */");
+	// Remove trailing modifiers for constant values
+	SourceCode = std::regex_replace(SourceCode, std::regex("(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa])"), "$1 /* removed modifier $2 */");
+	// Remove remaining modifiers for constant values
+	SourceCode = std::regex_replace(SourceCode, std::regex("(1?-)(c[0-9][\\.wxyz]*(?![\\.wxyz]))"), "$2 /* removed modifier $1 */");
 
 #ifndef D3D8TO9NOLOG
 	LOG << "> Dumping translated shader assembly:" << std::endl << std::endl << SourceCode << std::endl;


### PR DESCRIPTION
- Minor updates in vertex and pixel shaders regex to merge two negative lookbacks into one and slightly reduce the complexity of the regex
- Added code to get the arithmetic count in use
- Updated regex code that changes 'add' with a '-' modifier to 'sub' to make it more generic and work with swizzles and modifiers
- Added code to generically update any modifier on a constant by using the extra arithmetic functions available, this fixes one of the lighting issues with Star Wars Republic Commando
- Added code that changes 'mad' with a '-' modifier to 'sub', this fixes one of the lighting issues with Star Wars Republic Commando
- Added code that changes '_bx2' source modifier for constant to use _x2 destination modifier, this fixes a minor lighting issue with Silent Hill 2

This update completely resolves the lighting issues mentioned in [#24](https://github.com/crosire/d3d8to9/issues/24) and [#31](https://github.com/crosire/d3d8to9/issues/31).