### PR TITLE
Cache AdapterModes to reduce number of Direct3D9 API calls

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <vector>
 #include "d3d8types.hpp"
 
 class __declspec(uuid("1DD9E8DA-1C77-4D40-B0CF-98FEFDFF9512")) Direct3D8;
@@ -27,6 +28,7 @@ class Direct3D8 : public IUnknown
 
 public:
 	Direct3D8(IDirect3D9 *ProxyInterface);
+	~Direct3D8();
 
 	IDirect3D9 *GetProxyInterface() const { return ProxyInterface; }
 
@@ -50,6 +52,10 @@ public:
 
 private:
 	IDirect3D9 *const ProxyInterface;
+	static const UINT MaxAdapters = 8;
+	UINT CurrentAdapterCount = 0;
+	UINT CurrentAdapterModeCount[MaxAdapters] = { 0 };
+	std::vector<D3DDISPLAYMODE> CurrentAdapterModes[MaxAdapters];
 };
 
 class Direct3DDevice8 : public IUnknown

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -18,6 +18,36 @@ static const D3DFORMAT AdapterFormats[] = {
 Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
 	ProxyInterface(ProxyInterface)
 {
+	D3DDISPLAYMODE pMode;
+
+	CurrentAdapterCount = ProxyInterface->GetAdapterCount();
+
+	if (CurrentAdapterCount > MaxAdapters)
+	{
+		CurrentAdapterCount = MaxAdapters;
+	}
+
+	for (UINT Adapter = 0; Adapter < CurrentAdapterCount; Adapter++)
+	{
+		for (D3DFORMAT Format : AdapterFormats)
+		{
+			const UINT ModeCount = ProxyInterface->GetAdapterModeCount(Adapter, Format);
+
+			for (UINT Mode = 0; Mode < ModeCount; Mode++)
+			{
+				ProxyInterface->EnumAdapterModes(Adapter, Format, Mode, &pMode);
+				CurrentAdapterModes[Adapter].push_back(pMode);
+				CurrentAdapterModeCount[Adapter]++;
+			}
+		}
+	}
+}
+Direct3D8::~Direct3D8()
+{
+	for (UINT x = 0; x < CurrentAdapterCount; x++)
+	{
+		CurrentAdapterModes[x].clear();
+	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3D8::QueryInterface(REFIID riid, void **ppvObj)
@@ -61,7 +91,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::RegisterSoftwareDevice(void *pInitializeFun
 }
 UINT STDMETHODCALLTYPE Direct3D8::GetAdapterCount()
 {
-	return ProxyInterface->GetAdapterCount();
+	return CurrentAdapterCount;
 }
 HRESULT STDMETHODCALLTYPE Direct3D8::GetAdapterIdentifier(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER8 *pIdentifier)
 {
@@ -94,14 +124,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::GetAdapterIdentifier(UINT Adapter, DWORD Fl
 }
 UINT STDMETHODCALLTYPE Direct3D8::GetAdapterModeCount(UINT Adapter)
 {
-	UINT ModeCount = 0;
-
-	for (D3DFORMAT Format : AdapterFormats)
-	{
-		ModeCount += ProxyInterface->GetAdapterModeCount(Adapter, Format);
-	}
-
-	return ModeCount;
+	return CurrentAdapterModeCount[Adapter];
 }
 HRESULT STDMETHODCALLTYPE Direct3D8::EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode)
 {
@@ -110,23 +133,13 @@ HRESULT STDMETHODCALLTYPE Direct3D8::EnumAdapterModes(UINT Adapter, UINT Mode, D
 		return D3DERR_INVALIDCALL;
 	}
 
-	UINT ModeOffset = 0;
-
-	for (D3DFORMAT Format : AdapterFormats)
+	if (Adapter < CurrentAdapterCount && Mode < CurrentAdapterModeCount[Adapter])
 	{
-		const UINT ModeCount = ProxyInterface->GetAdapterModeCount(Adapter, Format);
-
-		if (ModeCount == 0)
-		{
-			continue;
-		}
-
-		if (Mode < ModeOffset + ModeCount)
-		{
-			return ProxyInterface->EnumAdapterModes(Adapter, Format, Mode - ModeOffset, pMode);
-		}
-
-		ModeOffset += ModeCount;
+		pMode->Format = CurrentAdapterModes[Adapter].at(Mode).Format;
+		pMode->Height = CurrentAdapterModes[Adapter].at(Mode).Height;
+		pMode->RefreshRate = CurrentAdapterModes[Adapter].at(Mode).RefreshRate;
+		pMode->Width = CurrentAdapterModes[Adapter].at(Mode).Width;
+		return D3D_OK;
 	}
 
 	return D3DERR_INVALIDCALL;


### PR DESCRIPTION
This update will cache AdapterModes to reduce number of Direct3D9 API calls.  This solves major performance issue on startup when using WineD3D.  See issue [#24](https://github.com/crosire/d3d8to9/issues/24).

The issue was that for each call to `EnumAdapterModes` d3d8to9 would make multiple calls to `GetAdapterModeCount`.  This would multiply the number of API calls significantly.  Furthermore, it seems there is a slight delay for each of these API calls when using WineD3D.  Calling them only once and caching the results significantly improves the performance.

This update will make is to that when a Direct3D8 device is created it will enum all adapter modes and store them in a vector.  Then when the game calls `EnumAdapterModes` it will retrieve them from the vector.