### PR TITLE
Fix Vertex and Index Buffer Locks that don't use D3DUSAGE_WRITEONLY

### DIFF
--- a/source/d3d8to9_index_buffer.cpp
+++ b/source/d3d8to9_index_buffer.cpp
@@ -97,6 +97,17 @@ D3DRESOURCETYPE STDMETHODCALLTYPE Direct3DIndexBuffer8::GetType()
 
 HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags)
 {
+	if ((Flags & D3DLOCK_DISCARD) != 0)
+	{
+		D3DINDEXBUFFER_DESC desc;
+		ProxyInterface->GetDesc(&desc);
+
+		if ((desc.Usage & D3DUSAGE_DYNAMIC) == 0 || (desc.Usage & D3DUSAGE_WRITEONLY) == 0)
+		{
+			Flags ^= D3DLOCK_DISCARD;
+		}
+	}
+
 	return ProxyInterface->Lock(OffsetToLock, SizeToLock, reinterpret_cast<void **>(ppbData), Flags);
 }
 HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::Unlock()

--- a/source/d3d8to9_vertex_buffer.cpp
+++ b/source/d3d8to9_vertex_buffer.cpp
@@ -102,7 +102,7 @@ HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::Lock(UINT OffsetToLock, UINT Si
 		D3DVERTEXBUFFER_DESC desc;
 		ProxyInterface->GetDesc(&desc);
 
-		if ((desc.Usage & D3DUSAGE_DYNAMIC) == 0)
+		if ((desc.Usage & D3DUSAGE_DYNAMIC) == 0 || (desc.Usage & D3DUSAGE_WRITEONLY) == 0)
 		{
 			Flags ^= D3DLOCK_DISCARD;
 		}


### PR DESCRIPTION
Update the Lock() functions for Vertex and Index Buffers so that they ignore the `D3DLOCK_DISCARD` flag if the `D3DUSAGE_WRITEONLY` flag is not set.  Fixes the missing texture issue with [Raymond 3](https://github.com/crosire/d3d8to9/issues/14).