### PR TITLE
Fix device lost error when creating device to fix issue with GTA III/VC

### DIFF
--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -18,7 +18,10 @@ std::ofstream LOG;
 extern "C" Direct3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
 {
 #ifndef D3D8TO9NOLOG
-	LOG.open("d3d8.log", std::ios::trunc);
+	if (!LOG.is_open())
+	{
+		LOG.open("d3d8.log", std::ios::trunc);
+	}
 
 	if (!LOG.is_open())
 	{

--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -18,13 +18,16 @@ std::ofstream LOG;
 extern "C" Direct3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
 {
 #ifndef D3D8TO9NOLOG
+	static bool LogMessageFlag = true;
+
 	if (!LOG.is_open())
 	{
 		LOG.open("d3d8.log", std::ios::trunc);
 	}
 
-	if (!LOG.is_open())
+	if (!LOG.is_open() && LogMessageFlag)
 	{
+		LogMessageFlag = false;
 		MessageBox(nullptr, TEXT("Failed to open debug log file \"d3d8.log\"!"), nullptr, MB_ICONWARNING);
 	}
 
@@ -65,7 +68,6 @@ extern "C" Direct3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
 				return nullptr;
 			}
 		}
-
 	}
 
 	return new Direct3D8(d3d);

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -14,7 +14,7 @@ static const D3DFORMAT AdapterFormats[] = {
 };
 
 IDirect3DDevice9 *pCurrentDeviceInterface = nullptr;
-D3DPRESENT_PARAMETERS *pCurrentPresentParams = nullptr;
+D3DPRESENT_PARAMETERS CurrentPresentParams;
 
 // IDirect3D8
 Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
@@ -206,9 +206,9 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 
-	if (hr == D3DERR_DEVICELOST && pCurrentDeviceInterface && pCurrentPresentParams)
+	if (hr == D3DERR_DEVICELOST && pCurrentDeviceInterface)
 	{
-		pCurrentDeviceInterface->Reset(pCurrentPresentParams);
+		pCurrentDeviceInterface->Reset(&CurrentPresentParams);
 		hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 	}
 
@@ -218,7 +218,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	}
 
 	pCurrentDeviceInterface = DeviceInterface;
-	pCurrentPresentParams = &PresentParams;
+	CopyMemory(&PresentParams, &CurrentPresentParams, sizeof(PresentParams));
 	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	return D3D_OK;

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -206,7 +206,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 
-	if ((hr & D3DERR_DEVICELOST) == D3DERR_DEVICELOST && pCurrentDeviceInterface && pCurrentPresentParams)
+	if (hr == D3DERR_DEVICELOST && pCurrentDeviceInterface && pCurrentPresentParams)
 	{
 		pCurrentDeviceInterface->Reset(pCurrentPresentParams);
 		hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -10,9 +10,10 @@ static const D3DFORMAT AdapterFormats[] = {
 	D3DFMT_X8R8G8B8,
 	D3DFMT_R5G6B5,
 	D3DFMT_X1R5G5B5,
-	D3DFMT_A1R5G5B5,
-	D3DFMT_A2R10G10B10
+	D3DFMT_A1R5G5B5
 };
+
+IDirect3DDevice9 *pCurrentDeviceInterface = nullptr;
 
 // IDirect3D8
 Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
@@ -202,13 +203,20 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	IDirect3DDevice9 *DeviceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
+	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
+
+	if ((hr & D3DERR_DEVICELOST) == D3DERR_DEVICELOST && pCurrentDeviceInterface)
+	{
+		while (pCurrentDeviceInterface->Release() != 0) {}
+		hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
+	}
 
 	if (FAILED(hr))
 	{
 		return hr;
 	}
 
+	pCurrentDeviceInterface = DeviceInterface;
 	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	return D3D_OK;

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -14,6 +14,7 @@ static const D3DFORMAT AdapterFormats[] = {
 };
 
 IDirect3DDevice9 *pCurrentDeviceInterface = nullptr;
+D3DPRESENT_PARAMETERS *pCurrentPresentParams = nullptr;
 
 // IDirect3D8
 Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
@@ -205,9 +206,9 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 
-	if ((hr & D3DERR_DEVICELOST) == D3DERR_DEVICELOST && pCurrentDeviceInterface)
+	if ((hr & D3DERR_DEVICELOST) == D3DERR_DEVICELOST && pCurrentDeviceInterface && pCurrentPresentParams)
 	{
-		while (pCurrentDeviceInterface->Release() != 0) {}
+		pCurrentDeviceInterface->Reset(pCurrentPresentParams);
 		hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 	}
 
@@ -217,6 +218,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	}
 
 	pCurrentDeviceInterface = DeviceInterface;
+	pCurrentPresentParams = &PresentParams;
 	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	return D3D_OK;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -988,7 +988,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetCurrentTexturePalette(UINT Palette
 {
 	if (!PaletteFlag)
 	{
-		PaletteNumber = (PaletteNumber & 0xFFF) | (PC_NOCOLLAPSE << 12);
+		return D3DERR_INVALIDCALL;
 	}
 	return ProxyInterface->SetCurrentTexturePalette(PaletteNumber);
 }

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1697,10 +1697,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 	SourceCode = std::regex_replace(SourceCode,
 		std::regex("(mad)([_satxd248]*) (r[0-9][\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*), (-)(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)(?![_\\.wxyz])"),
 		"sub$2 $3, $4, $7$8 /* changed 'mad' to 'sub' removed $5 removed modifier $6 */");
-	// Change '_bx2' modifier for constant values to use _x2 modifier
-	SourceCode = std::regex_replace(SourceCode,
-		std::regex("(...)(_sat|) (r[0-9][\\.wxyz]*), ([crtv][0-9][\\.wxyz]*)_bx2, (c[0-9][\\.wxyz]*)_bx2(?!,)"),
-		"$1_x2$2 $3, $4, $5 /* removed modifiers _bx2 added modifier _x2 */");
 	// Remove trailing modifiers for constant values
 	SourceCode = std::regex_replace(SourceCode,
 		std::regex("(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa])"),


### PR DESCRIPTION
This fix has several changes it in:

1. Error with lost device when CreateDevice is called:

The core issue with GTA III/VC mentioned in #39 is that GTA would try and create a new device when the old device was still there.  This caused it to return error `D3DERR_DEVICELOST`.  However GTA does not know how to properly handle this error and simply crashed.  The fix is to call `Release()` to release the previous device when a device lost error is seen so that a new device can be created.

It also seems that after the new device is created then GTA VC will call `Release()` and release the old device.  So this update will release the Direct3D9 device.  When GTA VC calls `Release()` then the Direct3D8 device (d3d8to9) will get released.

2. Invalid display type listed with 0-bits of color:

When testing GTA VC I noticed it showed a device with 0-bits of color (should only show 16-bit and 32-bit color).  I traced the issue to d3d8to9 using an unsupported `D3DFMT_A2R10G10B10` adapter format.  See [here](https://msdn.microsoft.com/en-us/library/ms886236.aspx) for documentation on Direct3D8 supported adapter formats.  Also you can look at 'd3d8types.h' from the DirectX SDK to see supported Direct3D8 formats.

Note: don't be confused by `D3DFMT_A2R10G10B10` and `D3DFMT_A2B10G10R10`, while similar these are different.  I also noticed that `D3DFMT_A2R10G10B10` did not exist in d3d8to9's 'd3d8types.cpp'.  I am not sure it should be added or not.

3. Issue with palette when palettes are not supported:

Also while I was testing this fix I found an issue in _Indiana Jones and the Emperor's Tomb_ where it would crash because of how pixels are handled in d3d8to9 (from this change [ e0d43b5](https://github.com/crosire/d3d8to9/commit/e0d43b56dfb86a62e1d39804fb0e86409fb62ce4) for the crash in _Need for Speed III_).  To fix this I changed the code to simply return `D3DERR_INVALIDCALL` when `SetCurrentTexturePalette` is called and palettes are not supported.  This fixes both _Indiana Jones and the Emperor's Tomb_ and _Need for Speed III_.

4. Logging will stop when Direct3DCreate8 is called more than once:

In some games `Direct3DCreate8()` is called more than once.  D3d8to9 tries to open the log file each time `Direct3DCreate8` is called.  This caused logging to stop at that point.  This update fixes that issue by checking if the log is already open before opening it again.
