### PR TITLE
Check VertexShader instruction count

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1293,9 +1293,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		const size_t InstructionPosition = SourceCode.find("instruction");
 		int InstructionCount = InstructionPosition > 2 && InstructionPosition < SourceCode.size() ? atoi(&SourceCode[InstructionPosition - 4]) : 0;
 
-		for (size_t j = 0; j < 2; j++)
+		for (size_t j = 0; j < 8; j++)
 		{
-			const std::string reg = "oD" + std::to_string(j);
+			const std::string reg = "oT" + std::to_string(j);
 
 			if (SourceCode.find(reg) != std::string::npos && InstructionCount < 128)
 			{
@@ -1303,9 +1303,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 				SourceCode.insert(DeclPosition + ConstantsCode.size(), "    mov " + reg + ", c0 /* initialize output register " + reg + " */\n");
 			}
 		}
-		for (size_t j = 0; j < 8; j++)
+		for (size_t j = 0; j < 2; j++)
 		{
-			const std::string reg = "oT" + std::to_string(j);
+			const std::string reg = "oD" + std::to_string(j);
 
 			if (SourceCode.find(reg) != std::string::npos && InstructionCount < 128)
 			{

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1289,12 +1289,17 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		#pragma region Fill registers with default value
 		SourceCode.insert(DeclPosition, ConstantsCode);
 
+		// Get number of arithmetic instructions used
+		const size_t InstructionPosition = SourceCode.find("instruction");
+		int InstructionCount = InstructionPosition > 2 && InstructionPosition < SourceCode.size() ? atoi(&SourceCode[InstructionPosition - 4]) : 0;
+
 		for (size_t j = 0; j < 2; j++)
 		{
 			const std::string reg = "oD" + std::to_string(j);
 
-			if (SourceCode.find(reg) != std::string::npos)
+			if (SourceCode.find(reg) != std::string::npos && InstructionCount < 128)
 			{
+				++InstructionCount;
 				SourceCode.insert(DeclPosition + ConstantsCode.size(), "    mov " + reg + ", c0 /* initialize output register " + reg + " */\n");
 			}
 		}
@@ -1302,8 +1307,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		{
 			const std::string reg = "oT" + std::to_string(j);
 
-			if (SourceCode.find(reg) != std::string::npos)
+			if (SourceCode.find(reg) != std::string::npos && InstructionCount < 128)
 			{
+				++InstructionCount;
 				SourceCode.insert(DeclPosition + ConstantsCode.size(), "    mov " + reg + ", c0 /* initialize output register " + reg + " */\n");
 			}
 		}
@@ -1311,8 +1317,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		{
 			const std::string reg = "r" + std::to_string(j);
 
-			if (SourceCode.find(reg) != std::string::npos)
+			if (SourceCode.find(reg) != std::string::npos && InstructionCount < 128)
 			{
+				++InstructionCount;
 				SourceCode.insert(DeclPosition + ConstantsCode.size(), "    mov " + reg + ", c0 /* initialize register " + reg + " */\n");
 			}
 		}


### PR DESCRIPTION
This update will check the VertexShader instruction count before adding any more instructions to the shader to ensure that the count never exceeds 128 instructions.  This will fix the issue with d3d8to9 and BloodRayne/BloodRayne 2.  See comments on these two threads:

- [Anyone get Reshade and Bloodrayne working?](https://reshade.me/forum/troubleshooting/973-bloodrayne-bloodrayne-2)
- [Unofficial "FSAA Patch" crashes on Windows 8/10](https://github.com/elishacloud/dxwrapper/issues/7)

A few notes here:
1. Initialization of the output registers are not always needed because sometimes (like the case with BloodRayne) they are already initialized in the existing VertexShader from the game.
2. It seems that only initialization of the oT (Texture Coordinate) register is actually needed.  I have not found a case where initialization of the other registers are needed.  The [ENBDev DX8 to DX9 convertor](http://enbdev.com/download_convertor_dx8todx9.htm) only initializes the oT (Texture Coordinate) register.  See comments [here](https://github.com/crosire/d3d8to9/pull/27#issuecomment-310911136).