### PR TITLE
Update Ref Count

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -13,9 +13,6 @@ static const D3DFORMAT AdapterFormats[] = {
 	D3DFMT_A1R5G5B5
 };
 
-IDirect3DDevice9 *pCurrentDeviceInterface = nullptr;
-D3DPRESENT_PARAMETERS CurrentPresentParams;
-
 // IDirect3D8
 Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
 	ProxyInterface(ProxyInterface)
@@ -206,19 +203,11 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 
-	if (hr == D3DERR_DEVICELOST && pCurrentDeviceInterface)
-	{
-		pCurrentDeviceInterface->Reset(&CurrentPresentParams);
-		hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
-	}
-
 	if (FAILED(hr))
 	{
 		return hr;
 	}
 
-	pCurrentDeviceInterface = DeviceInterface;
-	CopyMemory(&PresentParams, &CurrentPresentParams, sizeof(PresentParams));
 	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	return D3D_OK;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -18,15 +18,12 @@ struct VertexShaderInfo
 Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, BOOL EnableZBufferDiscarding) :
 	D3D(d3d), ProxyInterface(ProxyInterface), ZBufferDiscarding(EnableZBufferDiscarding)
 {
-	D3D->AddRef();
 	ProxyAddressLookupTable = new AddressLookupTable(this);
 	PaletteFlag = SupportsPalettes();
 }
 Direct3DDevice8::~Direct3DDevice8()
 {
 	delete ProxyAddressLookupTable;
-	ProxyInterface->Release();
-	D3D->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::QueryInterface(REFIID riid, void **ppvObj)
@@ -861,11 +858,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, Direct3DBaseT
 				*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DCubeTexture8>(CubeTextureInterface);
 				break;
 			default:
-				BaseTextureInterface->Release();
 				return D3DERR_INVALIDCALL;
 		}
-
-		BaseTextureInterface->Release();
 	}
 
 	return D3D_OK;

--- a/source/d3d8to9_index_buffer.cpp
+++ b/source/d3d8to9_index_buffer.cpp
@@ -9,20 +9,10 @@
 Direct3DIndexBuffer8::Direct3DIndexBuffer8(Direct3DDevice8 *Device, IDirect3DIndexBuffer9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DIndexBuffer8::~Direct3DIndexBuffer8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::QueryInterface(REFIID riid, void **ppvObj)
@@ -51,19 +41,7 @@ ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)

--- a/source/d3d8to9_surface.cpp
+++ b/source/d3d8to9_surface.cpp
@@ -9,20 +9,10 @@
 Direct3DSurface8::Direct3DSurface8(Direct3DDevice8 *Device, IDirect3DSurface9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DSurface8::~Direct3DSurface8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DSurface8::QueryInterface(REFIID riid, void **ppvObj)
@@ -50,19 +40,7 @@ ULONG STDMETHODCALLTYPE Direct3DSurface8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DSurface8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DSurface8::GetDevice(Direct3DDevice8 **ppDevice)

--- a/source/d3d8to9_swap_chain.cpp
+++ b/source/d3d8to9_swap_chain.cpp
@@ -9,20 +9,10 @@
 Direct3DSwapChain8::Direct3DSwapChain8(Direct3DDevice8 *Device, IDirect3DSwapChain9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DSwapChain8::~Direct3DSwapChain8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::QueryInterface(REFIID riid, void **ppvObj)
@@ -50,19 +40,7 @@ ULONG STDMETHODCALLTYPE Direct3DSwapChain8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DSwapChain8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion)

--- a/source/d3d8to9_texture.cpp
+++ b/source/d3d8to9_texture.cpp
@@ -9,20 +9,10 @@
 Direct3DTexture8::Direct3DTexture8(Direct3DDevice8 *Device, IDirect3DTexture9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DTexture8::~Direct3DTexture8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DTexture8::QueryInterface(REFIID riid, void **ppvObj)
@@ -52,19 +42,7 @@ ULONG STDMETHODCALLTYPE Direct3DTexture8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DTexture8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetDevice(Direct3DDevice8 **ppDevice)
@@ -182,20 +160,10 @@ Direct3DCubeTexture8::Direct3DCubeTexture8(Direct3DDevice8 *device, IDirect3DCub
 	ProxyInterface(ProxyInterface),
 	Device(device)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DCubeTexture8::~Direct3DCubeTexture8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::QueryInterface(REFIID riid, void **ppvObj)
@@ -225,19 +193,7 @@ ULONG STDMETHODCALLTYPE Direct3DCubeTexture8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DCubeTexture8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetDevice(Direct3DDevice8 **ppDevice)
@@ -355,20 +311,10 @@ Direct3DVolumeTexture8::Direct3DVolumeTexture8(Direct3DDevice8 *device, IDirect3
 	ProxyInterface(ProxyInterface),
 	Device(device)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DVolumeTexture8::~Direct3DVolumeTexture8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::QueryInterface(REFIID riid, void **ppvObj)
@@ -398,19 +344,7 @@ ULONG STDMETHODCALLTYPE Direct3DVolumeTexture8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DVolumeTexture8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetDevice(Direct3DDevice8 **ppDevice)

--- a/source/d3d8to9_vertex_buffer.cpp
+++ b/source/d3d8to9_vertex_buffer.cpp
@@ -9,20 +9,10 @@
 Direct3DVertexBuffer8::Direct3DVertexBuffer8(Direct3DDevice8 *Device, IDirect3DVertexBuffer9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DVertexBuffer8::~Direct3DVertexBuffer8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::QueryInterface(REFIID riid, void **ppvObj)
@@ -51,19 +41,7 @@ ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)

--- a/source/d3d8to9_volume.cpp
+++ b/source/d3d8to9_volume.cpp
@@ -9,20 +9,10 @@
 Direct3DVolume8::Direct3DVolume8(Direct3DDevice8 *Device, IDirect3DVolume9 *ProxyInterface) :
 	Device(Device), ProxyInterface(ProxyInterface)
 {
-	Device->AddRef();
 	Device->ProxyAddressLookupTable->SaveAddress(this, ProxyInterface);
 }
 Direct3DVolume8::~Direct3DVolume8()
 {
-	if (CleanUpFlag)
-	{
-		Device->ProxyAddressLookupTable->DeleteAddress(this);
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVolume8::QueryInterface(REFIID riid, void **ppvObj)
@@ -50,19 +40,7 @@ ULONG STDMETHODCALLTYPE Direct3DVolume8::AddRef()
 }
 ULONG STDMETHODCALLTYPE Direct3DVolume8::Release()
 {
-	const ULONG LastRefCount = ProxyInterface->Release();
-
-	if (LastRefCount == 0)
-	{
-		if (Active)
-		{
-			Active = false;
-			Device->Release();
-		}
-		//delete this;
-	}
-
-	return LastRefCount;
+	return ProxyInterface->Release();
 }
 
 HRESULT STDMETHODCALLTYPE Direct3DVolume8::GetDevice(Direct3DDevice8 **ppDevice)

--- a/source/lookup_table.cpp
+++ b/source/lookup_table.cpp
@@ -19,7 +19,7 @@ AddressLookupTable::~AddressLookupTable()
 		{
 			assert(AddressCache[i].back().Address8 != nullptr);
 
-			AddressCache[i].back().Address8->DeleteMe(false);
+			AddressCache[i].back().Address8->DeleteMe();
 
 			AddressCache[i].pop_back();
 		}

--- a/source/lookup_table.hpp
+++ b/source/lookup_table.hpp
@@ -120,14 +120,8 @@ class AddressLookupTableObject
 public:
 	virtual ~AddressLookupTableObject() { }
 
-	void DeleteMe(bool CleanUp = true)
+	void DeleteMe()
 	{
-		CleanUpFlag = CleanUp;
-
 		delete this;
 	}
-
-protected:
-	bool Active = true;
-	bool CleanUpFlag = true;
 };


### PR DESCRIPTION
This update will fix a couple of issues with the reference counter.  This fixes the crash in [GTA III/VC](https://github.com/crosire/d3d8to9/issues/39) when changing resolutions and the crash in [Serious Sam 1 & 2](https://github.com/crosire/d3d8to9/issues/39#issuecomment-323473718) when pressing alt+tab.

There are several fixes in this update:

1. This update stops adding a reference the constructor and releasing the reference in each destructor.

These extra references are not needed.  Plus they complicate the code and masks other issues (see below).  Also it seems like d3d8to9 does not always close out all the references here, though I cannot prove this.  This seems to be the main issue because the reason the games were crashing is because the previous device was still open and the reason the previous device was still open was because there were extra references on it.

2. This update stops releasing a reference after calling `GetType()` in the `GetTexture()` function.

This extra `Release()` would have been causing a crash in many games but since we added the extra reference in the constructor (see above) this issue was being masked.  The documentation [here](https://msdn.microsoft.com/en-us/library/windows/desktop/bb205883(v=vs.85).aspx), [here](https://msdn.microsoft.com/en-us/library/windows/desktop/bb205876(v=vs.85).aspx) and everywhere else I have looked says nothing about `GetType()` adding a reference counter.  From my testing `GetType()` never adds a reference counter.  So we should not have a `Release()` in the `GetTexture()` function.

3. This update no longer removes the object from the address cache in the destructor.

All the objects are removed only when the device is removed, to mirror Direct3D9's behavior.  Therefore we don't need to remove the cache because it will already get removed by the AddressLookupTable destructor [here](https://github.com/crosire/d3d8to9/blob/master/source/lookup_table.cpp#L24).

4. This update removes the previous workaround for the lost device see [here](https://github.com/crosire/d3d8to9/commit/436c84bae9a68b82f54cb22b5830d272e321c74d)

We no longer need that extra code for resetting the device now that the reference counter is corrected.  That was really only fixing the symptom not the root issue.