### PR TITLE
Fix Multisample support

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -199,6 +199,21 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
+	// Get multisample quality level
+	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
+	{
+		DWORD QualityLevels = 0;
+		if (ProxyInterface->CheckDeviceMultiSampleType(Adapter,
+			DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
+			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
+			ProxyInterface->CheckDeviceMultiSampleType(Adapter,
+				DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
+				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
+		{
+			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
+		}
+	}
+
 	IDirect3DDevice9 *DeviceInterface = nullptr;
 
 	HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -149,6 +149,24 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateAdditionalSwapChain(D3DPRESENT_
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
+	// Get multisample quality level
+	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
+	{
+		DWORD QualityLevels = 0;
+		D3DDEVICE_CREATION_PARAMETERS CreationParams;
+		ProxyInterface->GetCreationParameters(&CreationParams);
+
+		if (D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
+			CreationParams.DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
+			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
+			D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
+				CreationParams.DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
+				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
+		{
+			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
+		}
+	}
+
 	IDirect3DSwapChain9 *SwapChainInterface = nullptr;
 
 	const HRESULT hr = ProxyInterface->CreateAdditionalSwapChain(&PresentParams, &SwapChainInterface);
@@ -175,6 +193,24 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
+
+	// Get multisample quality level
+	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
+	{
+		DWORD QualityLevels = 0;
+		D3DDEVICE_CREATION_PARAMETERS CreationParams;
+		ProxyInterface->GetCreationParameters(&CreationParams);
+
+		if (D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
+			CreationParams.DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
+			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
+			D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
+				CreationParams.DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
+				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
+		{
+			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
+		}
+	}
 
 	return ProxyInterface->Reset(&PresentParams);
 }
@@ -353,20 +389,20 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 
 	*ppSurface = nullptr;
 
-	DWORD QualityLevels = 1;
-	D3DDEVICE_CREATION_PARAMETERS CreationParams;
-	ProxyInterface->GetCreationParameters(&CreationParams);
+	DWORD QualityLevels = 0;
 
-	HRESULT hr = D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
-
-	if (FAILED(hr))
+	// Get multisample quality level
+	if (MultiSample != D3DMULTISAMPLE_NONE)
 	{
-		return D3DERR_INVALIDCALL;
+		D3DDEVICE_CREATION_PARAMETERS CreationParams;
+		ProxyInterface->GetCreationParameters(&CreationParams);
+
+		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
 	}
 
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, QualityLevels - 1, Lockable, &SurfaceInterface, nullptr);
+	HRESULT hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, (QualityLevels != 0) ? QualityLevels - 1 : 0, Lockable, &SurfaceInterface, nullptr);
 
 	if (FAILED(hr))
 	{
@@ -386,20 +422,20 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width,
 
 	*ppSurface = nullptr;
 
-	DWORD QualityLevels = 1;
-	D3DDEVICE_CREATION_PARAMETERS CreationParams;
-	ProxyInterface->GetCreationParameters(&CreationParams);
+	DWORD QualityLevels = 0;
 
-	HRESULT hr = D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
-
-	if (FAILED(hr))
+	// Get multisample quality level
+	if (MultiSample != D3DMULTISAMPLE_NONE)
 	{
-		return D3DERR_INVALIDCALL;
+		D3DDEVICE_CREATION_PARAMETERS CreationParams;
+		ProxyInterface->GetCreationParameters(&CreationParams);
+
+		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
 	}
 
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, QualityLevels - 1, ZBufferDiscarding, &SurfaceInterface, nullptr);
+	HRESULT hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, (QualityLevels != 0) ? QualityLevels - 1 : 0, ZBufferDiscarding, &SurfaceInterface, nullptr);
 
 	if (FAILED(hr))
 	{

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -129,26 +129,28 @@ void ConvertPresentParameters(D3DPRESENT_PARAMETERS8 &Input, D3DPRESENT_PARAMETE
 	Output.FullScreen_RefreshRateInHz = Input.FullScreen_RefreshRateInHz;
 	Output.PresentationInterval = Input.FullScreen_PresentationInterval;
 
-	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD.
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/bb172588(v=vs.85).aspx
-	// Check for D3DMULTISAMPLE_NONMASKABLE and change it to D3DMULTISAMPLE_NONE for best D3D8 compatibility.
-	if (Output.SwapEffect != D3DSWAPEFFECT_DISCARD || Output.MultiSampleType == D3DMULTISAMPLE_NONMASKABLE)
+	// MultiSampleType must be D3DMULTISAMPLE_NONE unless SwapEffect has been set to D3DSWAPEFFECT_DISCARD
+	if (Output.SwapEffect != D3DSWAPEFFECT_DISCARD)
 	{
 		Output.MultiSampleType = D3DMULTISAMPLE_NONE;
 	}
 
-	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
-	// Update PresentationInterval when SwapEffect = D3DSWAPEFFECT_COPY_VSYNC and
-	// application is not windowed for best D3D8 compatibility
-	if (Output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED ||
-		(Output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC && !Output.Windowed))
+	// Remove Flags that are not compatible with multisampling
+	if (Output.MultiSampleType != D3DMULTISAMPLE_NONE)
 	{
-		Output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
+		Output.Flags &= ~D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
+	}
+
+	// D3DPRESENT_RATE_UNLIMITED is no longer supported in D3D9
+	if (Output.PresentationInterval == D3DPRESENT_RATE_UNLIMITED)
+	{
+		Output.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
 	}
 
 	// D3DSWAPEFFECT_COPY_VSYNC is no longer supported in D3D9
 	if (Output.SwapEffect == D3DSWAPEFFECT_COPY_VSYNC)
 	{
+		Output.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
 		Output.SwapEffect = D3DSWAPEFFECT_COPY;
 	}
 }


### PR DESCRIPTION
This fixes #66 and #67.

**Overview:**

There are three updates in this fix:

1. Updated CreateDevice, CreateAdditionalSwapChain, CreateRenderTarget, CreateDepthStencilSurface and Reset functions to support MultiSampleQuality by querying CheckDeviceMultiSampleType.  If MultiSampleType == D3DMULTISAMPLE_NONE then set MultiSampleQuality to 0.  Note: this is all the functions that use MultiSampling as seen [here](https://msdn.microsoft.com/en-us/library/windows/desktop/bb172574(v=vs.85).aspx).
2. Remove D3DPRESENTFLAG_LOCKABLE_BACKBUFFER flag when MultiSampleType != D3DMULTISAMPLE_NONE is detected.
3. Update unsupported D3DPRESENT_RATE_UNLIMITED flag to use D3DPRESENT_INTERVAL_IMMEDIATE rather than D3DPRESENT_INTERVAL_ONE to replicate more closely the d3d8 functionality.

**Testing:**

Tested the following games:

- Codemasters Race Driver 2
- Grand Theft Auto 3
- Grand Theft Auto Vice City
- Haegemonia Legions of Iron
- Hitman 2 Silent Assassin
- Indiana Jones and the Emperor's Tomb
- Legacy of Kain Blood Omen 2
- Max Payne
- Max Payne 2
- Moto Racer 3
- Need for Speed III
- Need For Speed Hot Pursuit 2
- Raymond 3
- Serious Sam The First Encounter
- Serious Sam The Second Encounter
- Silent Hill 2
- Star Wars Republic Commando
- Star Wars Starfighter
- True Crime New York City