### PR TITLE
Update Shader swizzle and debug support

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1415,7 +1415,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 
 		if (D3DXAssembleShader != nullptr)
 		{
-			hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM, &Assembly, &ErrorBuffer);
+			hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM_FLAGS, &Assembly, &ErrorBuffer);
 		}
 		else
 		{
@@ -2090,7 +2090,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 
 	if (D3DXAssembleShader != nullptr)
 	{
-		hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM, &Assembly, &ErrorBuffer);
+		hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM_FLAGS, &Assembly, &ErrorBuffer);
 	}
 	else
 	{

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1783,14 +1783,14 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 		// Replace one constant modifier using the dest register as a temporary register
 		size_t SourceSize = SourceCode.size();
 		SourceCode = std::regex_replace(SourceCode,
-			std::regex("    (...)(_[_satxd248]*|) (r[0-9][\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
-			"    mov $3, $9$10$13$14 /* added line */\n    $1$2 $3, $4$5$8$12$3$11$15 /* changed $9$10$13$14 to $3 */", std::regex_constants::format_first_only);
+			std::regex("    (...)(_[_satxd248]*|) (r[0-9])([\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
+			"    mov $3$4, $10$11$14$15 /* added line */\n    $1$2 $3$4, $5$6$9$13$3$12$16$4 /* changed $10$11$14$15 to $3$4 */", std::regex_constants::format_first_only);
 		// Replace one constant modifier on coissued commands using the dest register as a temporary register
 		if (SourceSize == SourceCode.size())
 		{
 			SourceCode = std::regex_replace(SourceCode,
-				std::regex("(    .*\\n)  \\+ (...)(_[_satxd248]*|) (r[0-9][\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
-				"    mov $4, $10$11$14$15 /* added line */\n$1  + $2$3 $4, $5$6$9$13$4$12$16 /* changed $10$11$14$15 to $4 */", std::regex_constants::format_first_only);
+				std::regex("(    .*\\n)  \\+ (...)(_[_satxd248]*|) (r[0-9])([\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
+				"    mov $4$5, $11$12$15$16 /* added line */\n$1  + $2$3 $4$5, $6$7$10$14$4$13$17$5 /* changed $11$12$15$16 to $4$5 */", std::regex_constants::format_first_only);
 		}
 		if (SourceSize == SourceCode.size())
 		{

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -398,11 +398,12 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 		ProxyInterface->GetCreationParameters(&CreationParams);
 
 		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
+		QualityLevels = (QualityLevels != 0) ? QualityLevels - 1 : 0;
 	}
 
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	HRESULT hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, (QualityLevels != 0) ? QualityLevels - 1 : 0, Lockable, &SurfaceInterface, nullptr);
+	HRESULT hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, QualityLevels, Lockable, &SurfaceInterface, nullptr);
 
 	if (FAILED(hr))
 	{
@@ -431,11 +432,12 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width,
 		ProxyInterface->GetCreationParameters(&CreationParams);
 
 		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
+		QualityLevels = (QualityLevels != 0) ? QualityLevels - 1 : 0;
 	}
 
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	HRESULT hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, (QualityLevels != 0) ? QualityLevels - 1 : 0, ZBufferDiscarding, &SurfaceInterface, nullptr);
+	HRESULT hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, QualityLevels, ZBufferDiscarding, &SurfaceInterface, nullptr);
 
 	if (FAILED(hr))
 	{

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1368,6 +1368,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 		#pragma endregion
 
 		SourceCode = std::regex_replace(SourceCode, std::regex("    \\/\\/ vs\\.1\\.1\\n((?! ).+\\n)+"), "");
+		SourceCode = std::regex_replace(SourceCode, std::regex("([^\\n]\\n)[\\s]*#line [0123456789]+.*\\n"), "$1");
 		SourceCode = std::regex_replace(SourceCode, std::regex("(oFog|oPts)\\.x"), "$1 /* removed swizzle */");
 		SourceCode = std::regex_replace(SourceCode, std::regex("(add|sub|mul|min|max) (oFog|oPts), ([cr][0-9]+), (.+)\\n"), "$1 $2, $3.x /* added swizzle */, $4\n");
 		SourceCode = std::regex_replace(SourceCode, std::regex("(add|sub|mul|min|max) (oFog|oPts), (.+), ([cr][0-9]+)\\n"), "$1 $2, $3, $4.x /* added swizzle */\n");
@@ -1414,7 +1415,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDecl
 
 		if (D3DXAssembleShader != nullptr)
 		{
-			hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, 0, &Assembly, &ErrorBuffer);
+			hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM, &Assembly, &ErrorBuffer);
 		}
 		else
 		{
@@ -1757,6 +1758,11 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 		std::regex("    \\/\\/ ps\\.1\\.[1-4]\\n((?! ).+\\n)+"),
 		"");
 
+	// Remove debug lines
+	SourceCode = std::regex_replace(SourceCode,
+		std::regex("([^\\n]\\n)[\\s]*#line [0123456789]+.*\\n"),
+		"$1");
+
 	// Fix '-' modifier for constant values when using 'add' arithmetic by changing it to use 'sub'
 	SourceCode = std::regex_replace(SourceCode,
 		std::regex("(add)([_satxd248]*) (r[0-9][\\.wxyz]*), ((1-|)[crtv][0-9][\\.wxyz_abdis2]*), (-)(c[0-9][\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)(?![_\\.wxyz])"),
@@ -2084,7 +2090,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 
 	if (D3DXAssembleShader != nullptr)
 	{
-		hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, 0, &Assembly, &ErrorBuffer);
+		hr = D3DXAssembleShader(SourceCode.data(), static_cast<UINT>(SourceCode.size()), nullptr, nullptr, D3DXASM, &Assembly, &ErrorBuffer);
 	}
 	else
 	{

--- a/source/d3dx9.hpp
+++ b/source/d3dx9.hpp
@@ -4,6 +4,15 @@
 
 #define D3DX_FILTER_NONE 1
 
+#define D3DXASM_DEBUG 0x0001
+#define D3DXASM_SKIPVALIDATION  0x0010
+
+#if _DEBUG
+#define D3DXASM D3DXASM_DEBUG
+#else
+#define D3DXASM  0
+#endif // _DEBUG
+
 struct D3DXMACRO
 {
 	LPCSTR Name;

--- a/source/d3dx9.hpp
+++ b/source/d3dx9.hpp
@@ -8,9 +8,9 @@
 #define D3DXASM_SKIPVALIDATION  0x0010
 
 #if _DEBUG
-#define D3DXASM D3DXASM_DEBUG
+#define D3DXASM_FLAGS D3DXASM_DEBUG
 #else
-#define D3DXASM  0
+#define D3DXASM_FLAGS  0
 #endif // _DEBUG
 
 struct D3DXMACRO


### PR DESCRIPTION
## Overview:

This pull fixes #64 and #70.  There are basically 4 changes in here:

1. Minor update of QualityLevels.

I just moved the [ternary operator](https://en.wikipedia.org/wiki/%3F:) out of the `CreateRenderTarget` and `CreateDepthStencilSurface` functions and hid it behind the if statement to clean up the code slightly.

2. Modified the PixelShader code to ensure that the swizzle comes at the end.  See comments [here](https://github.com/crosire/d3d8to9/issues/70#issuecomment-379416048).

This modifies two regex functions that remove modifiers on constants.  It adds a new regex group by changing `(r[0-9][\\.wxyz]*)` into `(r[0-9])([\\.wxyz]*)`.  This allows the swizzle to be in its own group so that we can ensure the swizzle comes last.

_Note: since a new group is added all the references to the regex groups need to be updated._

3. Removes the debug lines in shaders.

If the shader was compiled with debugging on there will be extra lines in it.

Example:
```asm
> Disassembling shader and translating assembly to Direct3D 9 compatible code ...
> Dumping translated shader assembly:

    vs_1_1

#line 2 "D:\Games\True Crime® New York City\memory"
    dcl_position v0
    dcl_blendweight v1
    dcl_blendindices v2
    mov r1, c0
    mov r0, c0
    mov oD0, c0
    mov oT1, c0
    mov oT0, c0
    dp3 r0.x, v1, c86
    dp4 oPos.x, v0, c92
    max r0.w, r0.x, c83.x

#line 13
    mul r0.xyz, r0.w, c87
    dp3 r1.x, v1, c84
    max r0.w, r1.x, c83.x
    dp3 r1.x, v1, c88
    mad r0.xyz, r0.w, c85, r0
    max r0.w, r1.x, c83.x
    dp4 oPos.y, v0, c93
    mad r0.xyz, r0.w, c89, r0
    dp4 oPos.z, v0, c94
    add r0.xyz, r0, c90
    dp4 oPos.w, v0, c95

#line 24
    mul r0.xyz, r0, c91
    dp4 oFog, v0, c81
    min oD0.xyz, r0, c83.y
    mov oD0.w, c90.w
    mov r0.xyz, c83
    mad r0, v2, r0.zzxy, c70
    mov oT0, r0
    mov oT1, r0

// approximately 27 instruction slots used
```

I added two new regex statements to remove these debugging lines.

4. Enable the D3DXASM_DEBUG flag when generating the debug build.

I set the `D3DXAssembleShader` function to automatically enable the D3DXASM_DEBUG flag when creating a debug build of d3d8to9.

## Testing: 

This is a pretty small change so it should have no affect on most games.  This mainly effects PixelShaders so I tested with games that are sensitive to PixelShaders.

Tested with:

* Silent Hill 2
* Star Wars Republic Commando
* TOCA Race Driver 2
* True Crime New York City
