### PR TITLE
Implemented clip planes cache

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -173,12 +173,18 @@ public:
 	AddressLookupTable *ProxyAddressLookupTable;
 
 private:
+	void ApplyClipPlanes();
+
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
 	INT CurrentBaseVertexIndex = 0;
 	const BOOL ZBufferDiscarding = FALSE;
 	DWORD CurrentVertexShaderHandle = 0, CurrentPixelShaderHandle = 0;
 	bool PaletteFlag = false;
+
+	static constexpr size_t MAX_CLIP_PLANES = 6;
+	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};
+	DWORD ClipPlaneRenderState = 0;
 };
 
 class Direct3DSwapChain8 : public IUnknown, public AddressLookupTableObject

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -43,10 +43,6 @@ Direct3D8::Direct3D8(IDirect3D9 *ProxyInterface) :
 }
 Direct3D8::~Direct3D8()
 {
-	for (UINT x = 0; x < CurrentAdapterCount; x++)
-	{
-		CurrentAdapterModes[x].clear();
-	}
 }
 
 HRESULT STDMETHODCALLTYPE Direct3D8::QueryInterface(REFIID riid, void **ppvObj)

--- a/source/lookup_table.cpp
+++ b/source/lookup_table.cpp
@@ -13,15 +13,11 @@ AddressLookupTable::AddressLookupTable(Direct3DDevice8 *Device) :
 }
 AddressLookupTable::~AddressLookupTable()
 {
-	for (UINT i = 0; i < 8; i++)
+	for (const auto& cache : AddressCache)
 	{
-		while (AddressCache[i].size())
+		for (const auto& entry : cache)
 		{
-			auto it = AddressCache[i].begin();
-
-			it->second->DeleteMe();
-
-			it = AddressCache[i].erase(it);
+			entry.second->DeleteMe();
 		}
 	}
 }


### PR DESCRIPTION
This PR consists of two commits,:

- One is a random code quality improvement - no point to clear containers explicitly in destructors as they are about to be destructed anyway.
- The main commit implements clip plane cache as an attempt to work around a possible D3D9 (and maybe D3D8) issue, as referenced in those places:
https://reshade.me/forum/troubleshooting/4165-d3d9-regression-with-clip-planes-affects-far-cry
https://github.com/elishacloud/dxwrapper/issues/5#issuecomment-378371756
https://github.com/CookiePLMonster/SilentPatchFarCry/commit/fb79e575e7cb9f9d07a8f35733be4b41caa69dca
https://www.vogons.org/viewtopic.php?f=8&t=40913&start=120#p661929

While D3D8 itself may not be affected by this issue, it will be affected with d3d8to9 (because D3D9, duh), so it makes sense to ship that. Additionally, fix is essentially free - imposes one extra D3D call for each draw call when clip planes are enabled. And, to be honest, they are pretty much never enabled, Far Cry is the only game I am aware of to ever use this D3D feature.