### PR TITLE
Remove swizzle from changed lines

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1790,13 +1790,13 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreatePixelShader(const DWORD *pFunct
 		size_t SourceSize = SourceCode.size();
 		SourceCode = std::regex_replace(SourceCode,
 			std::regex("    (...)(_[_satxd248]*|) (r[0-9])([\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
-			"    mov $3$4, $10$11$14$15 /* added line */\n    $1$2 $3$4, $5$6$9$13$3$12$16$4 /* changed $10$11$14$15 to $3$4 */", std::regex_constants::format_first_only);
+			"    mov $3$4, $10$11$14$15 /* added line */\n    $1$2 $3$4, $5$6$9$13$3$12$16 /* changed $10$11$14$15 to $3 */", std::regex_constants::format_first_only);
 		// Replace one constant modifier on coissued commands using the dest register as a temporary register
 		if (SourceSize == SourceCode.size())
 		{
 			SourceCode = std::regex_replace(SourceCode,
 				std::regex("(    .*\\n)  \\+ (...)(_[_satxd248]*|) (r[0-9])([\\.wxyz]*), (1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?(1?-?[crtv][0-9][\\.wxyz_abdis2]*, )?((1?-)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]|)|(1?-?)(c[0-9])([\\.wxyz]*)(_bx2|_bias|_x2|_d[zbwa]))(?![_\\.wxyz])"),
-				"    mov $4$5, $11$12$15$16 /* added line */\n$1  + $2$3 $4$5, $6$7$10$14$4$13$17$5 /* changed $11$12$15$16 to $4$5 */", std::regex_constants::format_first_only);
+				"    mov $4$5, $11$12$15$16 /* added line */\n$1  + $2$3 $4$5, $6$7$10$14$4$13$17 /* changed $11$12$15$16 to $4 */", std::regex_constants::format_first_only);
 		}
 		if (SourceSize == SourceCode.size())
 		{


### PR DESCRIPTION
## Overview

This fixes the comments mentioned [here](https://github.com/crosire/d3d8to9/issues/70#issuecomment-381148614) by @PatrickvL. This check-in removes the swizzle from the modified line while keeping the swizzle in the added `mov` line.

Since it keeps the swizzle on the `mov` line it still allows for the closest possible conversion.

However, it needs to remove the swizzle from the source modifier because not all source modifiers can be used together with a swizzle.  Note: a swizzle is just another form of a source modifier.

See documentation [here](https://msdn.microsoft.com/en-us/library/windows/desktop/bb219868(v=vs.85).aspx):

> * Negate can be combined with either the bias, signed scaling, or scalex2 modifier. When combined, negate is run last.
> * Invert cannot be combined with any other modifier.
> * Invert, negate, bias, signed scaling, and scalex2 can be combined with any of the selectors.
> * Source register modifiers should not be used on constant registers because they will cause undefined results. For version 1_4, modifiers on constants are not allowed and will fail validation.

Below are two examples of how the new translations look with this check-in.

**Example 1:**
So this:
```asm
dp3 r0.rgb, c0_bx2, t0_bx2
```

Gets changed to:
```asm
mov r0.xyz, c0 /* added line */
dp3 r0.xyz, r0_bx2 /* changed c0 to r0 */, t0_bx2
```

**Example 2:**
This:
```asm
    lrp r0.xyz, c0.w, r1, r0
  + mul r0.w, 1-v0.w, 1-c0.w
```

Gets changed to:
```asm
    mov r0.w, c0.w /* added line */
    lrp r0.xyz, c0.w, r1, r0
  + mul r0.w, 1-v0.w, 1-r0 /* changed c0.w to r0 */
```

## Testing: 

Tested with:

* Silent Hill 2
* Star Wars Republic Commando
* TOCA Race Driver 2
* True Crime New York City