### PR TITLE
Disable YUV formats on textures

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -145,8 +145,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CheckDeviceType(UINT Adapter, D3DDEVTYPE Ch
 }
 HRESULT STDMETHODCALLTYPE Direct3D8::CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat)
 {
-	if ((RType == D3DRTYPE_TEXTURE || RType == D3DRTYPE_VOLUMETEXTURE || RType == D3DRTYPE_CUBETEXTURE) &&
-		(CheckFormat == D3DFMT_UYVY || CheckFormat == D3DFMT_YUY2 || CheckFormat == MAKEFOURCC('Y', 'V', '1', '2') || CheckFormat == MAKEFOURCC('N', 'V', '1', '2')))
+	if (CheckFormat == D3DFMT_UYVY || CheckFormat == D3DFMT_YUY2 || CheckFormat == MAKEFOURCC('Y', 'V', '1', '2') || CheckFormat == MAKEFOURCC('N', 'V', '1', '2'))
 	{
 		return D3DERR_NOTAVAILABLE;
 	}

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -145,6 +145,11 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CheckDeviceType(UINT Adapter, D3DDEVTYPE Ch
 }
 HRESULT STDMETHODCALLTYPE Direct3D8::CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat)
 {
+	if ((RType == D3DRTYPE_TEXTURE || RType == D3DRTYPE_VOLUMETEXTURE || RType == D3DRTYPE_CUBETEXTURE) &&
+		(CheckFormat == D3DFMT_UYVY || CheckFormat == D3DFMT_YUY2 || CheckFormat == MAKEFOURCC('Y', 'V', '1', '2') || CheckFormat == MAKEFOURCC('N', 'V', '1', '2')))
+	{
+		return D3DERR_NOTAVAILABLE;
+	}
 	return ProxyInterface->CheckDeviceFormat(Adapter, DeviceType, AdapterFormat, Usage, RType, CheckFormat);
 }
 HRESULT STDMETHODCALLTYPE Direct3D8::CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType)


### PR DESCRIPTION
This pull request fixes issue #42.

## Overview

This change will return `D3DERR_NOTAVAILABLE` when an application queries using `CheckDeviceFormat` on any texture using a YUV format.  ATI and Nvidia already return this value for textures, so it should have no affect on these GPUs.  However, some Intel chips do not.  It appears that these Intel chips attempt to handle the formats but do not handle them correctly.

I believe with Direct3D9 that YUV is supposed to be unsupported on textures.  See [comment](https://www.winehq.org/pipermail/wine-patches/2014-February/130383.html) on WineD3D:

>         /* Some (all?) Windows drivers do not support YUV 3D textures, only 2D surfaces in
>          * StretchRect. Thus use StretchRect to draw the YUV surface onto the screen instead
>          * of drawPrimitive. */

## Notes

I did think about implementing full support for these formats into d3d8to9, but since most video cards don't support them I did not see the need to do that.

I also thought about blocking the creation of textures that use these formats.  I did some tests on Nvidia and it blocks the creation of a texture that use these formats.  However this issue was fixed by simply telling the application they are unsupported so I did not add any block on the creation of textures with these formats.

We can always add more fixes here later if there is an issue with other games.

## Testing

I tested with the following games:

 - Codemasters Race Driver 2
 - Grand Theft Auto 3
 - Grand Theft Auto Vice City
 - Haegemonia Legions of Iron
 - Haegemonia The Solon Heritage
 - Hitman 2 Silent Assassin
 - Legacy of Kain Blood Omen 2
 - Max Payne
 - Max Payne 2
 - Need for Speed III
 - Need For Speed Hot Pursuit 2
 - Raymond 3
 - Serious Sam The First Encounter
 - Serious Sam The Second Encounter
 - Silent Hill 2
 - Star Wars Republic Commando
 - Star Wars Starfighter
 - True Crime New York City