### PR TITLE
Check SetViewport region and fix issue with Depth Stencil Textures

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -180,6 +180,7 @@ private:
 	INT CurrentBaseVertexIndex = 0;
 	const BOOL ZBufferDiscarding = FALSE;
 	DWORD CurrentVertexShaderHandle = 0, CurrentPixelShaderHandle = 0;
+	IDirect3DSurface9 *pCurrentRenderTarget = nullptr;
 	bool PaletteFlag = false;
 
 	static constexpr size_t MAX_CLIP_PLANES = 6;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -410,6 +410,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 		return hr;
 	}
 
+	pCurrentRenderTarget = SurfaceInterface;
+
 	*ppSurface = new Direct3DSurface8(this, SurfaceInterface);
 
 	return D3D_OK;
@@ -621,6 +623,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(Direct3DSurface8 *pRe
 		{
 			return hr;
 		}
+
+		pCurrentRenderTarget = pRenderTarget->GetProxyInterface();
 	}
 
 	if (pNewZStencil != nullptr)
@@ -654,6 +658,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderTarget(Direct3DSurface8 **pp
 	{
 		return hr;
 	}
+
+	pCurrentRenderTarget = SurfaceInterface;
 
 	*ppRenderTarget = ProxyAddressLookupTable->FindAddress<Direct3DSurface8>(SurfaceInterface);
 
@@ -705,6 +711,16 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::MultiplyTransform(D3DTRANSFORMSTATETY
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetViewport(const D3DVIEWPORT8 *pViewport)
 {
+	if (pCurrentRenderTarget != nullptr)
+	{
+		D3DSURFACE_DESC Desc;
+		HRESULT hr = pCurrentRenderTarget->GetDesc(&Desc);
+		if (SUCCEEDED(hr) && (pViewport->Height > Desc.Height || pViewport->Width > Desc.Width))
+		{
+			return D3DERR_INVALIDCALL;
+		}
+	}
+
 	return ProxyInterface->SetViewport(pViewport);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetViewport(D3DVIEWPORT8 *pViewport)

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -273,7 +273,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateTexture(UINT Width, UINT Height
 		{
 			Usage |= D3DUSAGE_RENDERTARGET;
 		}
-		else
+		else if (Usage != D3DUSAGE_DEPTHSTENCIL)
 		{
 			Usage |= D3DUSAGE_DYNAMIC;
 		}


### PR DESCRIPTION
## Overview:

This pull fixes #76 and this pull fixes #79.

There are two changes here:

1. This will return D3DERR_INVALIDCALL if the pViewport describes a region that cannot exist within the render target surface.  See comments [here](https://github.com/crosire/d3d8to9/pull/78#issuecomment-389407210) for details on how this fixes the issue with Hydorah.
2. This takes the update from [here](https://github.com/Cxbx-Reloaded/d3d8to9/commit/c7236282d5c3f8ee871e26953cfdd2eeebe964cf).  This fixes an issue where D3DUSAGE_DYNAMIC was breaking Depth Stencil Textures.

## Testing:

I tested this with the following games:

* Codemasters Race Driver 2
* Grand Theft Auto 3
* Grand Theft Auto Vice City
* Haegemonia Legions of Iron
* Haegemonia The Solon Heritage
* Hitman 2 Silent Assassin
* Hydorah
* Indiana Jones and the Emperor's Tomb
* Legacy of Kain Blood Omen 2
* Max Payne
* Max Payne 2
* Moto Racer 3
* Need for Speed III
* Need For Speed Hot Pursuit 2
* Raymond 3
* Serious Sam The First Encounter
* Serious Sam The Second Encounter
* Silent Hill 2
* Star Wars Republic Commando
* Star Wars Starfighter
* True Crime New York City