### PR TITLE
Fix vsync, oPos register and RenderState

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -481,9 +481,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT H
 
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateOffscreenPlainSurface(Width, Height, Format, D3DPOOL_SCRATCH, &SurfaceInterface, nullptr);
+	const HRESULT hr = ProxyInterface->CreateOffscreenPlainSurface(Width, Height, Format, D3DPOOL_SYSTEMMEM, &SurfaceInterface, nullptr);
 
-	if (FAILED(hr))
+	if (FAILED(hr) && FAILED(ProxyInterface->CreateOffscreenPlainSurface(Width, Height, Format, D3DPOOL_SCRATCH, &SurfaceInterface, nullptr)))
 	{
 #ifndef D3D8TO9NOLOG
 		LOG << "> 'IDirect3DDevice9::CreateOffscreenPlainSurface' failed with error code " << std::hex << hr << std::dec << "!" << std::endl;


### PR DESCRIPTION
This pull request fixes #49 
This pull request fixes #63 
This pull request fixes #86 
This pull request fixes #103 
This pull also fixes [AquaNox](https://www.gog.com/game/aquanox), which never worked before with d3d8to9.

There are three main updates in this pull:

1. Fixes present parameters to match the documentation.

This will properly set the vsync based on whether the game is usin windowed or fullscreen.  This also removes the code that forced `D3DMULTISAMPLE_NONE`, as this broke some AA functions.

2. Fixes oPos register swizzles in VertexShader

AquaNox uses almost 100 VirtexShaders.  Several of them would set only  on the x and y components of the pPos register, which is not allowed in DirectX9.  See sample below.

Before fix (see error):
```asm
> Dumping translated shader assembly:

    vs_1_1
    dcl_position v0
    dcl_blendweight v1
    dcl_blendindices v2
    dcl_normal v3
    dcl_psize v4
    mov r0, c0 /* initialize register r0 */
    mov oT1, c0 /* initialize output register oT1 */
    mov oT0, c0 /* initialize output register oT0 */
    mul r0.xy, v3, c23
    add oPos.xy, r0, c22      //  <--  Error is here
    mov oT0.xy, v3
    mul r0.xy, v3, c25
    add oT1.xy, r0, c24

// approximately 5 instruction slots used

> Failed to reassemble shader:

d:\games\aquanox\memory(17,1): error X5350: Vertex shader must minimally write all four components (xyzw) of oPos output register.  Missing components(*): x/0 y/1 *z/2 *w/3
```

After fix:

```asm
> Dumping translated shader assembly:

    vs_1_1
    dcl_position v0
    dcl_blendweight v1
    dcl_blendindices v2
    dcl_normal v3
    dcl_psize v4
    mov r0, c0 /* initialize register r0 */
    mov oT1, c0 /* initialize output register oT1 */
    mov oT0, c0 /* initialize output register oT0 */
    mul r0.xy, v3, c23
    add oPos, r0, c22 /* removed oPos swizzles */
    mov oT0.xy, v3
    mul r0.xy, v3, c25
    add oT1.xy, r0, c24

// approximately 5 instruction slots used
```

3. Changes how SetRenderState/GetRenderState works with the following States: `D3DRS_LINEPATTERN`, `D3DRS_EDGEANTIALIAS` and `D3DRS_PATCHSEGMENTS`

These states were removed in DirectX9.  For `D3DRS_LINEPATTERN` and `D3DRS_PATCHSEGMENTS` this changes from returning `D3DERR_INVALIDCALL` to returning `D3D_OK`.  It also changes `D3DRS_EDGEANTIALIAS` to use `D3DRS_ANTIALIASEDLINEENABLE` instead.

These changes are required for AquaNox because AquaNox would monitor the return call and fail out if anything other than `D3D_OK` is returned.