### PR TITLE
Fix broken layout of virtual function tables when building with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,17 @@ cmake_minimum_required(VERSION 3.12)
 project(d3d8to9 CXX)
 
 set(SRCS
-  source/d3d8to9_base.cpp
+  source/d3d8.hpp
   source/d3d8to9.cpp
-  source/d3d8to9_device.cpp
   source/d3d8to9.hpp
+  source/d3d8to9_base.cpp
+  source/d3d8to9_device.cpp
   source/d3d8to9_index_buffer.cpp
   source/d3d8to9_surface.cpp
   source/d3d8to9_swap_chain.cpp
   source/d3d8to9_texture.cpp
   source/d3d8to9_vertex_buffer.cpp
   source/d3d8to9_volume.cpp
-  source/d3d8.hpp
   source/d3d8types.cpp
   source/d3d8types.hpp
   source/d3dx9.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRCS
   source/d3d8to9_texture.cpp
   source/d3d8to9_vertex_buffer.cpp
   source/d3d8to9_volume.cpp
+  source/d3d8.hpp
   source/d3d8types.cpp
   source/d3d8types.hpp
   source/d3dx9.hpp

--- a/d3d8to9.vcxproj
+++ b/d3d8to9.vcxproj
@@ -88,6 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="res\resource.h" />
+    <ClInclude Include="source\d3d8.hpp" />
     <ClInclude Include="source\d3d8to9.hpp" />
     <ClInclude Include="source\d3d8types.hpp" />
     <ClInclude Include="source\d3dx9.hpp" />

--- a/d3d8to9.vcxproj.filters
+++ b/d3d8to9.vcxproj.filters
@@ -29,6 +29,9 @@
     <ClInclude Include="res\resource.h">
       <Filter>resources</Filter>
     </ClInclude>
+    <ClInclude Include="source\d3d8.hpp">
+      <Filter>helpers</Filter>
+    </ClInclude>
     <ClInclude Include="source\d3d8to9.hpp" />
     <ClInclude Include="source\d3d8types.hpp">
       <Filter>helpers</Filter>

--- a/source/d3d8.hpp
+++ b/source/d3d8.hpp
@@ -1,0 +1,254 @@
+/**
+ * Copyright (C) 2015 Patrick Mours. All rights reserved.
+ * License: https://github.com/crosire/d3d8to9#license
+ */
+
+#pragma once
+
+#include "d3d8types.hpp"
+
+class DECLSPEC_UUID("1DD9E8DA-1C77-4D40-B0CF-98FEFDFF9512") IDirect3D8;
+class DECLSPEC_UUID("7385E5DF-8FE8-41D5-86B6-D7B48547B6CF") IDirect3DDevice8;
+class DECLSPEC_UUID("928C088B-76B9-4C6B-A536-A590853876CD") IDirect3DSwapChain8;
+class DECLSPEC_UUID("1B36BB7B-09B7-410A-B445-7D1430D7B33F") IDirect3DResource8;
+class DECLSPEC_UUID("B4211CFA-51B9-4A9F-AB78-DB99B2BB678E") IDirect3DBaseTexture8;
+class DECLSPEC_UUID("E4CDD575-2866-4F01-B12E-7EECE1EC9358") IDirect3DTexture8;
+class DECLSPEC_UUID("3EE5B968-2ACA-4C34-8BB5-7E0C3D19B750") IDirect3DCubeTexture8;
+class DECLSPEC_UUID("4B8AAAFA-140F-42BA-9131-597EAFAA2EAD") IDirect3DVolumeTexture8;
+class DECLSPEC_UUID("B96EEBCA-B326-4EA5-882F-2FF5BAE021DD") IDirect3DSurface8;
+class DECLSPEC_UUID("BD7349F5-14F1-42E4-9C79-972380DB40C0") IDirect3DVolume8;
+class DECLSPEC_UUID("8AEEEAC7-05F9-44D4-B591-000B0DF1CB95") IDirect3DVertexBuffer8;
+class DECLSPEC_UUID("0E689C9A-053D-44A0-9D92-DB0E3D750F86") IDirect3DIndexBuffer8;
+
+// MinGW support
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IDirect3D8, 0x1DD9E8DA, 0x1C77, 0x4D40, 0xB0, 0xCF, 0x98,0xFE,0xFD,0xFF,0x95,0x12)
+__CRT_UUID_DECL(IDirect3DDevice8, 0x7385E5DF, 0x8FE8, 0x41D5, 0x86, 0xB6, 0xD7,0xB4,0x85,0x47,0xB6,0xCF)
+__CRT_UUID_DECL(IDirect3DSwapChain8, 0x928C088B, 0x76B9, 0x4C6B, 0xA5, 0x36, 0xA5,0x90,0x85,0x38,0x76,0xCD)
+__CRT_UUID_DECL(IDirect3DResource8, 0x1B36BB7B, 0x09B7, 0x410A, 0xB4, 0x45, 0x7D,0x14,0x30,0xD7,0xB3,0x3F)
+__CRT_UUID_DECL(IDirect3DBaseTexture8, 0xB4211CFA, 0x51B9, 0x4A9F, 0xAB, 0x78, 0xDB,0x99,0xB2,0xBB,0x67,0x8E)
+__CRT_UUID_DECL(IDirect3DTexture8, 0xE4CDD575, 0x2866, 0x4F01, 0xB1, 0x2E, 0x7E,0xEC,0xE1,0xEC,0x93,0x58)
+__CRT_UUID_DECL(IDirect3DCubeTexture8, 0x3EE5B968, 0x2ACA, 0x4C34, 0x8B, 0xB5, 0x7E,0x0C,0x3D,0x19,0xB7,0x50)
+__CRT_UUID_DECL(IDirect3DVolumeTexture8, 0x4B8AAAFA, 0x140F, 0x42BA, 0x91, 0x31, 0x59,0x7E,0xAF,0xAA,0x2E,0xAD)
+__CRT_UUID_DECL(IDirect3DSurface8, 0xB96EEBCA, 0xB326, 0x4EA5, 0x88, 0x2F, 0x2F,0xF5,0xBA,0xE0,0x21,0xDD)
+__CRT_UUID_DECL(IDirect3DVolume8, 0xBD7349F5, 0x14F1, 0x42E4, 0x9C, 0x79, 0x97,0x23,0x80,0xDB,0x40,0xC0)
+__CRT_UUID_DECL(IDirect3DVertexBuffer8, 0x8AEEEAC7, 0x05F9, 0x44D4, 0xB5, 0x91, 0x00,0x0B,0x0D,0xF1,0xCB,0x95)
+__CRT_UUID_DECL(IDirect3DIndexBuffer8, 0x0E689C9A, 0x053D, 0x44A0, 0x9D, 0x92, 0xDB,0x0E,0x3D,0x75,0x0F,0x86)
+#endif
+
+class IDirect3D8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE RegisterSoftwareDevice(void *pInitializeFunction) = 0;
+	virtual UINT STDMETHODCALLTYPE GetAdapterCount() = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetAdapterIdentifier(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER8 *pIdentifier) = 0;
+	virtual UINT STDMETHODCALLTYPE GetAdapterModeCount(UINT Adapter) = 0;
+	virtual HRESULT STDMETHODCALLTYPE EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE *pMode) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceType(UINT Adapter, D3DDEVTYPE CheckType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS8 *pCaps) = 0;
+	virtual HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DDevice8 **ppReturnedDeviceInterface) = 0;
+};
+
+class IDirect3DDevice8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE TestCooperativeLevel() = 0;
+	virtual UINT STDMETHODCALLTYPE GetAvailableTextureMem() = 0;
+	virtual HRESULT STDMETHODCALLTYPE ResourceManagerDiscardBytes(DWORD Bytes) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDirect3D(IDirect3D8 **ppD3D8) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(D3DCAPS8 *pCaps) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDisplayMode(D3DDISPLAYMODE *pMode) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetCursorProperties(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface8 *pCursorBitmap) = 0;
+	virtual void STDMETHODCALLTYPE SetCursorPosition(UINT XScreenSpace, UINT YScreenSpace, DWORD Flags) = 0;
+	virtual BOOL STDMETHODCALLTYPE ShowCursor(BOOL bShow) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DSwapChain8 **ppSwapChain) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Reset(D3DPRESENT_PARAMETERS8 *pPresentationParameters) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetRasterStatus(D3DRASTER_STATUS *pRasterStatus) = 0;
+	virtual void STDMETHODCALLTYPE SetGammaRamp(DWORD Flags, const D3DGAMMARAMP *pRamp) = 0;
+	virtual void STDMETHODCALLTYPE GetGammaRamp(D3DGAMMARAMP *pRamp) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture8 **ppTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture8 **ppVolumeTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture8 **ppCubeTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer8 **ppVertexBuffer) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer8 **ppIndexBuffer) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable, IDirect3DSurface8 **ppSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, IDirect3DSurface8 **ppSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, IDirect3DSurface8 **ppSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CopyRects(IDirect3DSurface8 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects, IDirect3DSurface8 *pDestinationSurface, const POINT *pDestPointsArray) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UpdateTexture(IDirect3DBaseTexture8 *pSourceTexture, IDirect3DBaseTexture8 *pDestinationTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetFrontBuffer(IDirect3DSurface8 *pDestSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetRenderTarget(IDirect3DSurface8 *pRenderTarget, IDirect3DSurface8 *pNewZStencil) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetRenderTarget(IDirect3DSurface8 **ppRenderTarget) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDepthStencilSurface(IDirect3DSurface8 **ppZStencilSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE BeginScene() = 0;
+	virtual HRESULT STDMETHODCALLTYPE EndScene() = 0;
+	virtual HRESULT STDMETHODCALLTYPE Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix) = 0;
+	virtual HRESULT STDMETHODCALLTYPE MultiplyTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetViewport(const D3DVIEWPORT8 *pViewport) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetViewport(D3DVIEWPORT8 *pViewport) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetMaterial(const D3DMATERIAL8 *pMaterial) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetMaterial(D3DMATERIAL8 *pMaterial) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetLight(DWORD Index, const D3DLIGHT8 *pLight) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetLight(DWORD Index, D3DLIGHT8 *pLight) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LightEnable(DWORD Index, BOOL Enable) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetLightEnable(DWORD Index, BOOL *pEnable) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetClipPlane(DWORD Index, const float *pPlane) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetClipPlane(DWORD Index, float *pPlane) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue) = 0;
+	virtual HRESULT STDMETHODCALLTYPE BeginStateBlock() = 0;
+	virtual HRESULT STDMETHODCALLTYPE EndStateBlock(DWORD *pToken) = 0;
+	virtual HRESULT STDMETHODCALLTYPE ApplyStateBlock(DWORD Token) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CaptureStateBlock(DWORD Token) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DeleteStateBlock(DWORD Token) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateStateBlock(D3DSTATEBLOCKTYPE Type, DWORD *pToken) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetClipStatus(const D3DCLIPSTATUS8 *pClipStatus) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetClipStatus(D3DCLIPSTATUS8 *pClipStatus) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetTexture(DWORD Stage, IDirect3DBaseTexture8 **ppTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetTexture(DWORD Stage, IDirect3DBaseTexture8 *pTexture) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD *pValue) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value) = 0;
+	virtual HRESULT STDMETHODCALLTYPE ValidateDevice(DWORD *pNumPasses) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetInfo(DWORD DevInfoID, void *pDevInfoStruct, DWORD DevInfoStructSize) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPaletteEntries(UINT PaletteNumber, const PALETTEENTRY *pEntries) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetCurrentTexturePalette(UINT PaletteNumber) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetCurrentTexturePalette(UINT *PaletteNumber) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT MinIndex, UINT NumVertices, UINT StartIndex, UINT PrimitiveCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertexIndices, UINT PrimitiveCount, const void *pIndexData, D3DFORMAT IndexDataFormat, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride) = 0;
+	virtual HRESULT STDMETHODCALLTYPE ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer8 *pDestBuffer, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreateVertexShader(const DWORD *pDeclaration, const DWORD *pFunction, DWORD *pHandle, DWORD Usage) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetVertexShader(DWORD Handle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShader(DWORD *pHandle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DeleteVertexShader(DWORD Handle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetVertexShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderDeclaration(DWORD Handle, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 *pStreamData, UINT Stride) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 **ppStreamData, UINT *pStride) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetIndices(IDirect3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetIndices(IDirect3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex) = 0;
+	virtual HRESULT STDMETHODCALLTYPE CreatePixelShader(const DWORD *pFunction, DWORD *pHandle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPixelShader(DWORD Handle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShader(DWORD *pHandle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DeletePixelShader(DWORD Handle) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPixelShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawRectPatch(UINT Handle, const float *pNumSegs, const D3DRECTPATCH_INFO *pRectPatchInfo) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DrawTriPatch(UINT Handle, const float *pNumSegs, const D3DTRIPATCH_INFO *pTriPatchInfo) = 0;
+	virtual HRESULT STDMETHODCALLTYPE DeletePatch(UINT Handle) = 0;
+};
+
+class IDirect3DSwapChain8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer) = 0;
+};
+
+class IDirect3DResource8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) = 0;
+	virtual DWORD STDMETHODCALLTYPE SetPriority(DWORD PriorityNew) = 0;
+	virtual DWORD STDMETHODCALLTYPE GetPriority() = 0;
+	virtual void STDMETHODCALLTYPE PreLoad() = 0;
+	virtual D3DRESOURCETYPE STDMETHODCALLTYPE GetType() = 0;
+};
+
+class IDirect3DBaseTexture8 : public IDirect3DResource8
+{
+public:
+	virtual DWORD STDMETHODCALLTYPE SetLOD(DWORD LODNew) = 0;
+	virtual DWORD STDMETHODCALLTYPE GetLOD() = 0;
+	virtual DWORD STDMETHODCALLTYPE GetLevelCount() = 0;
+};
+
+class IDirect3DTexture8 : public IDirect3DBaseTexture8
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetSurfaceLevel(UINT Level, IDirect3DSurface8 **ppSurfaceLevel) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect(UINT Level) = 0;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(const RECT *pDirtyRect) = 0;
+};
+
+class IDirect3DCubeTexture8 : public IDirect3DBaseTexture8
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetCubeMapSurface(D3DCUBEMAP_FACES FaceType, UINT Level, IDirect3DSurface8 **ppCubeMapSurface) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DCUBEMAP_FACES FaceType, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect(D3DCUBEMAP_FACES FaceType, UINT Level) = 0;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(D3DCUBEMAP_FACES FaceType, const RECT *pDirtyRect) = 0;
+};
+
+class IDirect3DVolumeTexture8 : public IDirect3DBaseTexture8
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DVOLUME_DESC8 *pDesc) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetVolumeLevel(UINT Level, IDirect3DVolume8 **ppVolumeLevel) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LockBox(UINT Level, D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UnlockBox(UINT Level) = 0;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyBox(const D3DBOX *pDirtyBox) = 0;
+};
+
+class IDirect3DSurface8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DSURFACE_DESC8 *pDesc) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect() = 0;
+};
+
+class IDirect3DVolume8 : public IUnknown
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) = 0;
+	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) = 0;
+	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer) = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVOLUME_DESC8 *pDesc) = 0;
+	virtual HRESULT STDMETHODCALLTYPE LockBox(D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE UnlockBox() = 0;
+};
+
+class IDirect3DVertexBuffer8 : public IDirect3DResource8
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Unlock() = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVERTEXBUFFER_DESC *pDesc) = 0;
+};
+
+class IDirect3DIndexBuffer8 : public IDirect3DResource8
+{
+public:
+	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags) = 0;
+	virtual HRESULT STDMETHODCALLTYPE Unlock() = 0;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DINDEXBUFFER_DESC *pDesc) = 0;
+};

--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -15,7 +15,7 @@ PFN_D3DXLoadSurfaceFromSurface D3DXLoadSurfaceFromSurface = nullptr;
 std::ofstream LOG;
 #endif
 
-extern "C" Direct3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
+extern "C" IDirect3D8 *WINAPI Direct3DCreate8(UINT SDKVersion)
 {
 #ifndef D3D8TO9NOLOG
 	static bool LogMessageFlag = true;

--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -6,40 +6,10 @@
 #pragma once
 
 #include <vector>
-#include "d3d8types.hpp"
-
-class DECLSPEC_UUID("1DD9E8DA-1C77-4D40-B0CF-98FEFDFF9512") Direct3D8;
-class DECLSPEC_UUID("7385E5DF-8FE8-41D5-86B6-D7B48547B6CF") Direct3DDevice8;
-class DECLSPEC_UUID("928C088B-76B9-4C6B-A536-A590853876CD") Direct3DSwapChain8;
-class DECLSPEC_UUID("1B36BB7B-09B7-410A-B445-7D1430D7B33F") Direct3DResource8;
-class DECLSPEC_UUID("B4211CFA-51B9-4A9F-AB78-DB99B2BB678E") Direct3DBaseTexture8;
-class DECLSPEC_UUID("E4CDD575-2866-4F01-B12E-7EECE1EC9358") Direct3DTexture8;
-class DECLSPEC_UUID("3EE5B968-2ACA-4C34-8BB5-7E0C3D19B750") Direct3DCubeTexture8;
-class DECLSPEC_UUID("4B8AAAFA-140F-42BA-9131-597EAFAA2EAD") Direct3DVolumeTexture8;
-class DECLSPEC_UUID("B96EEBCA-B326-4EA5-882F-2FF5BAE021DD") Direct3DSurface8;
-class DECLSPEC_UUID("BD7349F5-14F1-42E4-9C79-972380DB40C0") Direct3DVolume8;
-class DECLSPEC_UUID("8AEEEAC7-05F9-44D4-B591-000B0DF1CB95") Direct3DVertexBuffer8;
-class DECLSPEC_UUID("0E689C9A-053D-44A0-9D92-DB0E3D750F86") Direct3DIndexBuffer8;
-
-// MinGW support
-#ifdef __CRT_UUID_DECL
-__CRT_UUID_DECL(Direct3D8, 0x1DD9E8DA, 0x1C77, 0x4D40, 0xB0, 0xCF, 0x98,0xFE,0xFD,0xFF,0x95,0x12)
-__CRT_UUID_DECL(Direct3DDevice8, 0x7385E5DF, 0x8FE8, 0x41D5, 0x86, 0xB6, 0xD7,0xB4,0x85,0x47,0xB6,0xCF)
-__CRT_UUID_DECL(Direct3DSwapChain8, 0x928C088B, 0x76B9, 0x4C6B, 0xA5, 0x36, 0xA5,0x90,0x85,0x38,0x76,0xCD)
-__CRT_UUID_DECL(Direct3DResource8, 0x1B36BB7B, 0x09B7, 0x410A, 0xB4, 0x45, 0x7D,0x14,0x30,0xD7,0xB3,0x3F)
-__CRT_UUID_DECL(Direct3DBaseTexture8, 0xB4211CFA, 0x51B9, 0x4A9F, 0xAB, 0x78, 0xDB,0x99,0xB2,0xBB,0x67,0x8E)
-__CRT_UUID_DECL(Direct3DTexture8, 0xE4CDD575, 0x2866, 0x4F01, 0xB1, 0x2E, 0x7E,0xEC,0xE1,0xEC,0x93,0x58)
-__CRT_UUID_DECL(Direct3DCubeTexture8, 0x3EE5B968, 0x2ACA, 0x4C34, 0x8B, 0xB5, 0x7E,0x0C,0x3D,0x19,0xB7,0x50)
-__CRT_UUID_DECL(Direct3DVolumeTexture8, 0x4B8AAAFA, 0x140F, 0x42BA, 0x91, 0x31, 0x59,0x7E,0xAF,0xAA,0x2E,0xAD)
-__CRT_UUID_DECL(Direct3DSurface8, 0xB96EEBCA, 0xB326, 0x4EA5, 0x88, 0x2F, 0x2F,0xF5,0xBA,0xE0,0x21,0xDD)
-__CRT_UUID_DECL(Direct3DVolume8, 0xBD7349F5, 0x14F1, 0x42E4, 0x9C, 0x79, 0x97,0x23,0x80,0xDB,0x40,0xC0)
-__CRT_UUID_DECL(Direct3DVertexBuffer8, 0x8AEEEAC7, 0x05F9, 0x44D4, 0xB5, 0x91, 0x00,0x0B,0x0D,0xF1,0xCB,0x95)
-__CRT_UUID_DECL(Direct3DIndexBuffer8, 0x0E689C9A, 0x053D, 0x44A0, 0x9D, 0x92, 0xDB,0x0E,0x3D,0x75,0x0F,0x86)
-#endif
-
+#include "d3d8.hpp"
 #include "interface_query.hpp"
 
-class Direct3D8 : public IUnknown
+class Direct3D8 : public IDirect3D8
 {
 	Direct3D8(const Direct3D8 &) = delete;
 	Direct3D8 &operator=(const Direct3D8 &) = delete;
@@ -54,19 +24,19 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE RegisterSoftwareDevice(void *pInitializeFunction);
-	virtual UINT STDMETHODCALLTYPE GetAdapterCount();
-	virtual HRESULT STDMETHODCALLTYPE GetAdapterIdentifier(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER8 *pIdentifier);
-	virtual UINT STDMETHODCALLTYPE GetAdapterModeCount(UINT Adapter);
-	virtual HRESULT STDMETHODCALLTYPE EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode);
-	virtual HRESULT STDMETHODCALLTYPE GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE *pMode);
-	virtual HRESULT STDMETHODCALLTYPE CheckDeviceType(UINT Adapter, D3DDEVTYPE CheckType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed);
-	virtual HRESULT STDMETHODCALLTYPE CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat);
-	virtual HRESULT STDMETHODCALLTYPE CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType);
-	virtual HRESULT STDMETHODCALLTYPE CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat);
-	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS8 *pCaps);
-	virtual HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter);
-	virtual HRESULT STDMETHODCALLTYPE CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS8 *pPresentationParameters, Direct3DDevice8 **ppReturnedDeviceInterface);
+	virtual HRESULT STDMETHODCALLTYPE RegisterSoftwareDevice(void *pInitializeFunction) override;
+	virtual UINT STDMETHODCALLTYPE GetAdapterCount() override;
+	virtual HRESULT STDMETHODCALLTYPE GetAdapterIdentifier(UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER8 *pIdentifier) override;
+	virtual UINT STDMETHODCALLTYPE GetAdapterModeCount(UINT Adapter) override;
+	virtual HRESULT STDMETHODCALLTYPE EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode) override;
+	virtual HRESULT STDMETHODCALLTYPE GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE *pMode) override;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceType(UINT Adapter, D3DDEVTYPE CheckType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed) override;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat) override;
+	virtual HRESULT STDMETHODCALLTYPE CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType) override;
+	virtual HRESULT STDMETHODCALLTYPE CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS8 *pCaps) override;
+	virtual HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DDevice8 **ppReturnedDeviceInterface) override;
 
 private:
 	IDirect3D9 *const ProxyInterface;
@@ -76,7 +46,7 @@ private:
 	std::vector<D3DDISPLAYMODE> CurrentAdapterModes[MaxAdapters];
 };
 
-class Direct3DDevice8 : public IUnknown
+class Direct3DDevice8 : public IDirect3DDevice8
 {
 	Direct3DDevice8(const Direct3DDevice8 &) = delete;
 	Direct3DDevice8 &operator=(const Direct3DDevice8 &) = delete;
@@ -91,100 +61,100 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE TestCooperativeLevel();
-	virtual UINT STDMETHODCALLTYPE GetAvailableTextureMem();
-	virtual HRESULT STDMETHODCALLTYPE ResourceManagerDiscardBytes(DWORD Bytes);
-	virtual HRESULT STDMETHODCALLTYPE GetDirect3D(Direct3D8 **ppD3D8);
-	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(D3DCAPS8 *pCaps);
-	virtual HRESULT STDMETHODCALLTYPE GetDisplayMode(D3DDISPLAYMODE *pMode);
-	virtual HRESULT STDMETHODCALLTYPE GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters);
-	virtual HRESULT STDMETHODCALLTYPE SetCursorProperties(UINT XHotSpot, UINT YHotSpot, Direct3DSurface8 *pCursorBitmap);
-	virtual void STDMETHODCALLTYPE SetCursorPosition(UINT XScreenSpace, UINT YScreenSpace, DWORD Flags);
-	virtual BOOL STDMETHODCALLTYPE ShowCursor(BOOL bShow);
-	virtual HRESULT STDMETHODCALLTYPE CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS8 *pPresentationParameters, Direct3DSwapChain8 **ppSwapChain);
-	virtual HRESULT STDMETHODCALLTYPE Reset(D3DPRESENT_PARAMETERS8 *pPresentationParameters);
-	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion);
-	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, Direct3DSurface8 **ppBackBuffer);
-	virtual HRESULT STDMETHODCALLTYPE GetRasterStatus(D3DRASTER_STATUS *pRasterStatus);
-	virtual void STDMETHODCALLTYPE SetGammaRamp(DWORD Flags, const D3DGAMMARAMP *pRamp);
-	virtual void STDMETHODCALLTYPE GetGammaRamp(D3DGAMMARAMP *pRamp);
-	virtual HRESULT STDMETHODCALLTYPE CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DTexture8 **ppTexture);
-	virtual HRESULT STDMETHODCALLTYPE CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DVolumeTexture8 **ppVolumeTexture);
-	virtual HRESULT STDMETHODCALLTYPE CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DCubeTexture8 **ppCubeTexture);
-	virtual HRESULT STDMETHODCALLTYPE CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, Direct3DVertexBuffer8 **ppVertexBuffer);
-	virtual HRESULT STDMETHODCALLTYPE CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DIndexBuffer8 **ppIndexBuffer);
-	virtual HRESULT STDMETHODCALLTYPE CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable, Direct3DSurface8 **ppSurface);
-	virtual HRESULT STDMETHODCALLTYPE CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, Direct3DSurface8 **ppSurface);
-	virtual HRESULT STDMETHODCALLTYPE CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, Direct3DSurface8 **ppSurface);
-	virtual HRESULT STDMETHODCALLTYPE CopyRects(Direct3DSurface8 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects, Direct3DSurface8 *pDestinationSurface, const POINT *pDestPointsArray);
-	virtual HRESULT STDMETHODCALLTYPE UpdateTexture(Direct3DBaseTexture8 *pSourceTexture, Direct3DBaseTexture8 *pDestinationTexture);
-	virtual HRESULT STDMETHODCALLTYPE GetFrontBuffer(Direct3DSurface8 *pDestSurface);
-	virtual HRESULT STDMETHODCALLTYPE SetRenderTarget(Direct3DSurface8 *pRenderTarget, Direct3DSurface8 *pNewZStencil);
-	virtual HRESULT STDMETHODCALLTYPE GetRenderTarget(Direct3DSurface8 **ppRenderTarget);
-	virtual HRESULT STDMETHODCALLTYPE GetDepthStencilSurface(Direct3DSurface8 **ppZStencilSurface);
-	virtual HRESULT STDMETHODCALLTYPE BeginScene();
-	virtual HRESULT STDMETHODCALLTYPE EndScene();
-	virtual HRESULT STDMETHODCALLTYPE Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil);
-	virtual HRESULT STDMETHODCALLTYPE SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix);
-	virtual HRESULT STDMETHODCALLTYPE GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix);
-	virtual HRESULT STDMETHODCALLTYPE MultiplyTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix);
-	virtual HRESULT STDMETHODCALLTYPE SetViewport(const D3DVIEWPORT8 *pViewport);
-	virtual HRESULT STDMETHODCALLTYPE GetViewport(D3DVIEWPORT8 *pViewport);
-	virtual HRESULT STDMETHODCALLTYPE SetMaterial(const D3DMATERIAL8 *pMaterial);
-	virtual HRESULT STDMETHODCALLTYPE GetMaterial(D3DMATERIAL8 *pMaterial);
-	virtual HRESULT STDMETHODCALLTYPE SetLight(DWORD Index, const D3DLIGHT8 *pLight);
-	virtual HRESULT STDMETHODCALLTYPE GetLight(DWORD Index, D3DLIGHT8 *pLight);
-	virtual HRESULT STDMETHODCALLTYPE LightEnable(DWORD Index, BOOL Enable);
-	virtual HRESULT STDMETHODCALLTYPE GetLightEnable(DWORD Index, BOOL *pEnable);
-	virtual HRESULT STDMETHODCALLTYPE SetClipPlane(DWORD Index, const float *pPlane);
-	virtual HRESULT STDMETHODCALLTYPE GetClipPlane(DWORD Index, float *pPlane);
-	virtual HRESULT STDMETHODCALLTYPE SetRenderState(D3DRENDERSTATETYPE State, DWORD Value);
-	virtual HRESULT STDMETHODCALLTYPE GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue);
-	virtual HRESULT STDMETHODCALLTYPE BeginStateBlock();
-	virtual HRESULT STDMETHODCALLTYPE EndStateBlock(DWORD *pToken);
-	virtual HRESULT STDMETHODCALLTYPE ApplyStateBlock(DWORD Token);
-	virtual HRESULT STDMETHODCALLTYPE CaptureStateBlock(DWORD Token);
-	virtual HRESULT STDMETHODCALLTYPE DeleteStateBlock(DWORD Token);
-	virtual HRESULT STDMETHODCALLTYPE CreateStateBlock(D3DSTATEBLOCKTYPE Type, DWORD *pToken);
-	virtual HRESULT STDMETHODCALLTYPE SetClipStatus(const D3DCLIPSTATUS8 *pClipStatus);
-	virtual HRESULT STDMETHODCALLTYPE GetClipStatus(D3DCLIPSTATUS8 *pClipStatus);
-	virtual HRESULT STDMETHODCALLTYPE GetTexture(DWORD Stage, Direct3DBaseTexture8 **ppTexture);
-	virtual HRESULT STDMETHODCALLTYPE SetTexture(DWORD Stage, Direct3DBaseTexture8 *pTexture);
-	virtual HRESULT STDMETHODCALLTYPE GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD *pValue);
-	virtual HRESULT STDMETHODCALLTYPE SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value);
-	virtual HRESULT STDMETHODCALLTYPE ValidateDevice(DWORD *pNumPasses);
-	virtual HRESULT STDMETHODCALLTYPE GetInfo(DWORD DevInfoID, void *pDevInfoStruct, DWORD DevInfoStructSize);
-	virtual HRESULT STDMETHODCALLTYPE SetPaletteEntries(UINT PaletteNumber, const PALETTEENTRY *pEntries);
-	virtual HRESULT STDMETHODCALLTYPE GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries);
-	virtual HRESULT STDMETHODCALLTYPE SetCurrentTexturePalette(UINT PaletteNumber);
-	virtual HRESULT STDMETHODCALLTYPE GetCurrentTexturePalette(UINT *PaletteNumber);
-	virtual HRESULT STDMETHODCALLTYPE DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount);
-	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT MinIndex, UINT NumVertices, UINT StartIndex, UINT PrimitiveCount);
-	virtual HRESULT STDMETHODCALLTYPE DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride);
-	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertexIndices, UINT PrimitiveCount, const void *pIndexData, D3DFORMAT IndexDataFormat, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride);
-	virtual HRESULT STDMETHODCALLTYPE ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, Direct3DVertexBuffer8 *pDestBuffer, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE CreateVertexShader(const DWORD *pDeclaration, const DWORD *pFunction, DWORD *pHandle, DWORD Usage);
-	virtual HRESULT STDMETHODCALLTYPE SetVertexShader(DWORD Handle);
-	virtual HRESULT STDMETHODCALLTYPE GetVertexShader(DWORD *pHandle);
-	virtual HRESULT STDMETHODCALLTYPE DeleteVertexShader(DWORD Handle);
-	virtual HRESULT STDMETHODCALLTYPE SetVertexShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount);
-	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount);
-	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderDeclaration(DWORD Handle, void *pData, DWORD *pSizeOfData);
-	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData);
-	virtual HRESULT STDMETHODCALLTYPE SetStreamSource(UINT StreamNumber, Direct3DVertexBuffer8 *pStreamData, UINT Stride);
-	virtual HRESULT STDMETHODCALLTYPE GetStreamSource(UINT StreamNumber, Direct3DVertexBuffer8 **ppStreamData, UINT *pStride);
-	virtual HRESULT STDMETHODCALLTYPE SetIndices(Direct3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex);
-	virtual HRESULT STDMETHODCALLTYPE GetIndices(Direct3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex);
-	virtual HRESULT STDMETHODCALLTYPE CreatePixelShader(const DWORD *pFunction, DWORD *pHandle);
-	virtual HRESULT STDMETHODCALLTYPE SetPixelShader(DWORD Handle);
-	virtual HRESULT STDMETHODCALLTYPE GetPixelShader(DWORD *pHandle);
-	virtual HRESULT STDMETHODCALLTYPE DeletePixelShader(DWORD Handle);
-	virtual HRESULT STDMETHODCALLTYPE SetPixelShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount);
-	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount);
-	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData);
-	virtual HRESULT STDMETHODCALLTYPE DrawRectPatch(UINT Handle, const float *pNumSegs, const D3DRECTPATCH_INFO *pRectPatchInfo);
-	virtual HRESULT STDMETHODCALLTYPE DrawTriPatch(UINT Handle, const float *pNumSegs, const D3DTRIPATCH_INFO *pTriPatchInfo);
-	virtual HRESULT STDMETHODCALLTYPE DeletePatch(UINT Handle);
+	virtual HRESULT STDMETHODCALLTYPE TestCooperativeLevel() override;
+	virtual UINT STDMETHODCALLTYPE GetAvailableTextureMem() override;
+	virtual HRESULT STDMETHODCALLTYPE ResourceManagerDiscardBytes(DWORD Bytes) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDirect3D(IDirect3D8 **ppD3D8) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDeviceCaps(D3DCAPS8 *pCaps) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDisplayMode(D3DDISPLAYMODE *pMode) override;
+	virtual HRESULT STDMETHODCALLTYPE GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters) override;
+	virtual HRESULT STDMETHODCALLTYPE SetCursorProperties(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface8 *pCursorBitmap) override;
+	virtual void STDMETHODCALLTYPE SetCursorPosition(UINT XScreenSpace, UINT YScreenSpace, DWORD Flags) override;
+	virtual BOOL STDMETHODCALLTYPE ShowCursor(BOOL bShow) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DSwapChain8 **ppSwapChain) override;
+	virtual HRESULT STDMETHODCALLTYPE Reset(D3DPRESENT_PARAMETERS8 *pPresentationParameters) override;
+	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) override;
+	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer) override;
+	virtual HRESULT STDMETHODCALLTYPE GetRasterStatus(D3DRASTER_STATUS *pRasterStatus) override;
+	virtual void STDMETHODCALLTYPE SetGammaRamp(DWORD Flags, const D3DGAMMARAMP *pRamp) override;
+	virtual void STDMETHODCALLTYPE GetGammaRamp(D3DGAMMARAMP *pRamp) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture8 **ppTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture8 **ppVolumeTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture8 **ppCubeTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer8 **ppVertexBuffer) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer8 **ppIndexBuffer) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable, IDirect3DSurface8 **ppSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, IDirect3DSurface8 **ppSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, IDirect3DSurface8 **ppSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE CopyRects(IDirect3DSurface8 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects, IDirect3DSurface8 *pDestinationSurface, const POINT *pDestPointsArray) override;
+	virtual HRESULT STDMETHODCALLTYPE UpdateTexture(IDirect3DBaseTexture8 *pSourceTexture, IDirect3DBaseTexture8 *pDestinationTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE GetFrontBuffer(IDirect3DSurface8 *pDestSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE SetRenderTarget(IDirect3DSurface8 *pRenderTarget, IDirect3DSurface8 *pNewZStencil) override;
+	virtual HRESULT STDMETHODCALLTYPE GetRenderTarget(IDirect3DSurface8 **ppRenderTarget) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDepthStencilSurface(IDirect3DSurface8 **ppZStencilSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE BeginScene() override;
+	virtual HRESULT STDMETHODCALLTYPE EndScene() override;
+	virtual HRESULT STDMETHODCALLTYPE Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) override;
+	virtual HRESULT STDMETHODCALLTYPE SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) override;
+	virtual HRESULT STDMETHODCALLTYPE GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix) override;
+	virtual HRESULT STDMETHODCALLTYPE MultiplyTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) override;
+	virtual HRESULT STDMETHODCALLTYPE SetViewport(const D3DVIEWPORT8 *pViewport) override;
+	virtual HRESULT STDMETHODCALLTYPE GetViewport(D3DVIEWPORT8 *pViewport) override;
+	virtual HRESULT STDMETHODCALLTYPE SetMaterial(const D3DMATERIAL8 *pMaterial) override;
+	virtual HRESULT STDMETHODCALLTYPE GetMaterial(D3DMATERIAL8 *pMaterial) override;
+	virtual HRESULT STDMETHODCALLTYPE SetLight(DWORD Index, const D3DLIGHT8 *pLight) override;
+	virtual HRESULT STDMETHODCALLTYPE GetLight(DWORD Index, D3DLIGHT8 *pLight) override;
+	virtual HRESULT STDMETHODCALLTYPE LightEnable(DWORD Index, BOOL Enable) override;
+	virtual HRESULT STDMETHODCALLTYPE GetLightEnable(DWORD Index, BOOL *pEnable) override;
+	virtual HRESULT STDMETHODCALLTYPE SetClipPlane(DWORD Index, const float *pPlane) override;
+	virtual HRESULT STDMETHODCALLTYPE GetClipPlane(DWORD Index, float *pPlane) override;
+	virtual HRESULT STDMETHODCALLTYPE SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) override;
+	virtual HRESULT STDMETHODCALLTYPE GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue) override;
+	virtual HRESULT STDMETHODCALLTYPE BeginStateBlock() override;
+	virtual HRESULT STDMETHODCALLTYPE EndStateBlock(DWORD *pToken) override;
+	virtual HRESULT STDMETHODCALLTYPE ApplyStateBlock(DWORD Token) override;
+	virtual HRESULT STDMETHODCALLTYPE CaptureStateBlock(DWORD Token) override;
+	virtual HRESULT STDMETHODCALLTYPE DeleteStateBlock(DWORD Token) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateStateBlock(D3DSTATEBLOCKTYPE Type, DWORD *pToken) override;
+	virtual HRESULT STDMETHODCALLTYPE SetClipStatus(const D3DCLIPSTATUS8 *pClipStatus) override;
+	virtual HRESULT STDMETHODCALLTYPE GetClipStatus(D3DCLIPSTATUS8 *pClipStatus) override;
+	virtual HRESULT STDMETHODCALLTYPE GetTexture(DWORD Stage, IDirect3DBaseTexture8 **ppTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE SetTexture(DWORD Stage, IDirect3DBaseTexture8 *pTexture) override;
+	virtual HRESULT STDMETHODCALLTYPE GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD *pValue) override;
+	virtual HRESULT STDMETHODCALLTYPE SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value) override;
+	virtual HRESULT STDMETHODCALLTYPE ValidateDevice(DWORD *pNumPasses) override;
+	virtual HRESULT STDMETHODCALLTYPE GetInfo(DWORD DevInfoID, void *pDevInfoStruct, DWORD DevInfoStructSize) override;
+	virtual HRESULT STDMETHODCALLTYPE SetPaletteEntries(UINT PaletteNumber, const PALETTEENTRY *pEntries) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries) override;
+	virtual HRESULT STDMETHODCALLTYPE SetCurrentTexturePalette(UINT PaletteNumber) override;
+	virtual HRESULT STDMETHODCALLTYPE GetCurrentTexturePalette(UINT *PaletteNumber) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT MinIndex, UINT NumVertices, UINT StartIndex, UINT PrimitiveCount) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertexIndices, UINT PrimitiveCount, const void *pIndexData, D3DFORMAT IndexDataFormat, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride) override;
+	virtual HRESULT STDMETHODCALLTYPE ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer8 *pDestBuffer, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE CreateVertexShader(const DWORD *pDeclaration, const DWORD *pFunction, DWORD *pHandle, DWORD Usage) override;
+	virtual HRESULT STDMETHODCALLTYPE SetVertexShader(DWORD Handle) override;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShader(DWORD *pHandle) override;
+	virtual HRESULT STDMETHODCALLTYPE DeleteVertexShader(DWORD Handle) override;
+	virtual HRESULT STDMETHODCALLTYPE SetVertexShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount) override;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount) override;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderDeclaration(DWORD Handle, void *pData, DWORD *pSizeOfData) override;
+	virtual HRESULT STDMETHODCALLTYPE GetVertexShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData) override;
+	virtual HRESULT STDMETHODCALLTYPE SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 *pStreamData, UINT Stride) override;
+	virtual HRESULT STDMETHODCALLTYPE GetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 **ppStreamData, UINT *pStride) override;
+	virtual HRESULT STDMETHODCALLTYPE SetIndices(IDirect3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex) override;
+	virtual HRESULT STDMETHODCALLTYPE GetIndices(IDirect3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex) override;
+	virtual HRESULT STDMETHODCALLTYPE CreatePixelShader(const DWORD *pFunction, DWORD *pHandle) override;
+	virtual HRESULT STDMETHODCALLTYPE SetPixelShader(DWORD Handle) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShader(DWORD *pHandle) override;
+	virtual HRESULT STDMETHODCALLTYPE DeletePixelShader(DWORD Handle) override;
+	virtual HRESULT STDMETHODCALLTYPE SetPixelShaderConstant(DWORD Register, const void *pConstantData, DWORD ConstantCount) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderConstant(DWORD Register, void *pConstantData, DWORD ConstantCount) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPixelShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawRectPatch(UINT Handle, const float *pNumSegs, const D3DRECTPATCH_INFO *pRectPatchInfo) override;
+	virtual HRESULT STDMETHODCALLTYPE DrawTriPatch(UINT Handle, const float *pNumSegs, const D3DTRIPATCH_INFO *pTriPatchInfo) override;
+	virtual HRESULT STDMETHODCALLTYPE DeletePatch(UINT Handle) override;
 
 	AddressLookupTable *ProxyAddressLookupTable;
 
@@ -204,7 +174,7 @@ private:
 	DWORD ClipPlaneRenderState = 0;
 };
 
-class Direct3DSwapChain8 : public IUnknown, public AddressLookupTableObject
+class Direct3DSwapChain8 : public IDirect3DSwapChain8, public AddressLookupTableObject
 {
 	Direct3DSwapChain8(const Direct3DSwapChain8 &) = delete;
 	Direct3DSwapChain8 &operator=(const Direct3DSwapChain8 &) = delete;
@@ -219,35 +189,15 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion);
-	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, Direct3DSurface8 **ppBackBuffer);
+	virtual HRESULT STDMETHODCALLTYPE Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) override;
+	virtual HRESULT STDMETHODCALLTYPE GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer) override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DSwapChain9 *const ProxyInterface;
 };
 
-class Direct3DResource8 : public IUnknown
-{
-public:
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) = 0;
-	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) = 0;
-	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) = 0;
-	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) = 0;
-	virtual DWORD STDMETHODCALLTYPE SetPriority(DWORD PriorityNew) = 0;
-	virtual DWORD STDMETHODCALLTYPE GetPriority() = 0;
-	virtual void STDMETHODCALLTYPE PreLoad() = 0;
-	virtual D3DRESOURCETYPE STDMETHODCALLTYPE GetType() = 0;
-};
-
-class Direct3DBaseTexture8 : public Direct3DResource8
-{
-public:
-	virtual DWORD STDMETHODCALLTYPE SetLOD(DWORD LODNew) = 0;
-	virtual DWORD STDMETHODCALLTYPE GetLOD() = 0;
-	virtual DWORD STDMETHODCALLTYPE GetLevelCount() = 0;
-};
-class Direct3DTexture8 : public Direct3DBaseTexture8, public AddressLookupTableObject
+class Direct3DTexture8 : public IDirect3DTexture8, public AddressLookupTableObject
 {
 	Direct3DTexture8(const Direct3DTexture8 &) = delete;
 	Direct3DTexture8 &operator=(const Direct3DTexture8 &) = delete;
@@ -262,7 +212,7 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
 	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
 	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
 	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
@@ -275,17 +225,17 @@ public:
 	virtual DWORD STDMETHODCALLTYPE GetLOD() override;
 	virtual DWORD STDMETHODCALLTYPE GetLevelCount() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc);
-	virtual HRESULT STDMETHODCALLTYPE GetSurfaceLevel(UINT Level, Direct3DSurface8 **ppSurfaceLevel);
-	virtual HRESULT STDMETHODCALLTYPE LockRect(UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE UnlockRect(UINT Level);
-	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(const RECT *pDirtyRect);
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc) override;
+	virtual HRESULT STDMETHODCALLTYPE GetSurfaceLevel(UINT Level, IDirect3DSurface8 **ppSurfaceLevel) override;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect(UINT Level) override;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(const RECT *pDirtyRect) override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DTexture9 *const ProxyInterface;
 };
-class Direct3DCubeTexture8 : public Direct3DBaseTexture8, public AddressLookupTableObject
+class Direct3DCubeTexture8 : public IDirect3DCubeTexture8, public AddressLookupTableObject
 {
 	Direct3DCubeTexture8(const Direct3DCubeTexture8 &) = delete;
 	Direct3DCubeTexture8 &operator=(const Direct3DCubeTexture8 &) = delete;
@@ -300,7 +250,7 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
 	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
 	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
 	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
@@ -313,17 +263,17 @@ public:
 	virtual DWORD STDMETHODCALLTYPE GetLOD() override;
 	virtual DWORD STDMETHODCALLTYPE GetLevelCount() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc);
-	virtual HRESULT STDMETHODCALLTYPE GetCubeMapSurface(D3DCUBEMAP_FACES FaceType, UINT Level, Direct3DSurface8 **ppCubeMapSurface);
-	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DCUBEMAP_FACES FaceType, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE UnlockRect(D3DCUBEMAP_FACES FaceType, UINT Level);
-	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(D3DCUBEMAP_FACES FaceType, const RECT *pDirtyRect);
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC8 *pDesc) override;
+	virtual HRESULT STDMETHODCALLTYPE GetCubeMapSurface(D3DCUBEMAP_FACES FaceType, UINT Level, IDirect3DSurface8 **ppCubeMapSurface) override;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DCUBEMAP_FACES FaceType, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect(D3DCUBEMAP_FACES FaceType, UINT Level) override;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyRect(D3DCUBEMAP_FACES FaceType, const RECT *pDirtyRect) override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DCubeTexture9 *const ProxyInterface;
 };
-class Direct3DVolumeTexture8 : public Direct3DBaseTexture8, public AddressLookupTableObject
+class Direct3DVolumeTexture8 : public IDirect3DVolumeTexture8, public AddressLookupTableObject
 {
 	Direct3DVolumeTexture8(const Direct3DVolumeTexture8 &) = delete;
 	Direct3DVolumeTexture8 &operator=(const Direct3DVolumeTexture8 &) = delete;
@@ -338,7 +288,7 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
 	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
 	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
 	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
@@ -351,18 +301,18 @@ public:
 	virtual DWORD STDMETHODCALLTYPE GetLOD() override;
 	virtual DWORD STDMETHODCALLTYPE GetLevelCount() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DVOLUME_DESC8 *pDesc);
-	virtual HRESULT STDMETHODCALLTYPE GetVolumeLevel(UINT Level, Direct3DVolume8 **ppVolumeLevel);
-	virtual HRESULT STDMETHODCALLTYPE LockBox(UINT Level, D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE UnlockBox(UINT Level);
-	virtual HRESULT STDMETHODCALLTYPE AddDirtyBox(const D3DBOX *pDirtyBox);
+	virtual HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DVOLUME_DESC8 *pDesc) override;
+	virtual HRESULT STDMETHODCALLTYPE GetVolumeLevel(UINT Level, IDirect3DVolume8 **ppVolumeLevel) override;
+	virtual HRESULT STDMETHODCALLTYPE LockBox(UINT Level, D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE UnlockBox(UINT Level) override;
+	virtual HRESULT STDMETHODCALLTYPE AddDirtyBox(const D3DBOX *pDirtyBox) override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DVolumeTexture9 *const ProxyInterface;
 };
 
-class Direct3DSurface8 : public IUnknown, public AddressLookupTableObject
+class Direct3DSurface8 : public IDirect3DSurface8, public AddressLookupTableObject
 {
 	Direct3DSurface8(const Direct3DSurface8 &) = delete;
 	Direct3DSurface8 &operator=(const Direct3DSurface8 &) = delete;
@@ -377,21 +327,21 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice);
-	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData);
-	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid);
-	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer);
-	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DSURFACE_DESC8 *pDesc);
-	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE UnlockRect();
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
+	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
+	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DSURFACE_DESC8 *pDesc) override;
+	virtual HRESULT STDMETHODCALLTYPE LockRect(D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE UnlockRect() override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DSurface9 *const ProxyInterface;
 };
 
-class Direct3DVolume8 : public IUnknown, public AddressLookupTableObject
+class Direct3DVolume8 : public IDirect3DVolume8, public AddressLookupTableObject
 {
 	Direct3DVolume8(const Direct3DVolume8 &) = delete;
 	Direct3DVolume8 &operator=(const Direct3DVolume8 &) = delete;
@@ -406,21 +356,21 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice);
-	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData);
-	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid);
-	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer);
-	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVOLUME_DESC8 *pDesc);
-	virtual HRESULT STDMETHODCALLTYPE LockBox(D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE UnlockBox();
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
+	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
+	virtual HRESULT STDMETHODCALLTYPE GetContainer(REFIID riid, void **ppContainer) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVOLUME_DESC8 *pDesc) override;
+	virtual HRESULT STDMETHODCALLTYPE LockBox(D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE UnlockBox() override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DVolume9 *const ProxyInterface;
 };
 
-class Direct3DVertexBuffer8 : public Direct3DResource8, public AddressLookupTableObject
+class Direct3DVertexBuffer8 : public IDirect3DVertexBuffer8, public AddressLookupTableObject
 {
 	Direct3DVertexBuffer8(const Direct3DVertexBuffer8 &) = delete;
 	Direct3DVertexBuffer8 &operator=(const Direct3DVertexBuffer8 &) = delete;
@@ -435,7 +385,7 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
 	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
 	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
 	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
@@ -444,16 +394,16 @@ public:
 	virtual void STDMETHODCALLTYPE PreLoad() override;
 	virtual D3DRESOURCETYPE STDMETHODCALLTYPE GetType() override;
 
-	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE Unlock();
-	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVERTEXBUFFER_DESC *pDesc);
+	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE Unlock() override;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DVERTEXBUFFER_DESC *pDesc) override;
 
 private:
 	Direct3DDevice8 *const Device;
 	IDirect3DVertexBuffer9 *const ProxyInterface;
 };
 
-class Direct3DIndexBuffer8 : public Direct3DResource8, public AddressLookupTableObject
+class Direct3DIndexBuffer8 : public IDirect3DIndexBuffer8, public AddressLookupTableObject
 {
 	Direct3DIndexBuffer8(const Direct3DIndexBuffer8 &) = delete;
 	Direct3DIndexBuffer8 &operator=(const Direct3DIndexBuffer8 &) = delete;
@@ -468,7 +418,7 @@ public:
 	virtual ULONG STDMETHODCALLTYPE AddRef() override;
 	virtual ULONG STDMETHODCALLTYPE Release() override;
 
-	virtual HRESULT STDMETHODCALLTYPE GetDevice(Direct3DDevice8 **ppDevice) override;
+	virtual HRESULT STDMETHODCALLTYPE GetDevice(IDirect3DDevice8 **ppDevice) override;
 	virtual HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID refguid, const void *pData, DWORD SizeOfData, DWORD Flags) override;
 	virtual HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID refguid, void *pData, DWORD *pSizeOfData) override;
 	virtual HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID refguid) override;
@@ -477,9 +427,9 @@ public:
 	virtual void STDMETHODCALLTYPE PreLoad() override;
 	virtual D3DRESOURCETYPE STDMETHODCALLTYPE GetType() override;
 
-	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags);
-	virtual HRESULT STDMETHODCALLTYPE Unlock();
-	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DINDEXBUFFER_DESC *pDesc);
+	virtual HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags) override;
+	virtual HRESULT STDMETHODCALLTYPE Unlock() override;
+	virtual HRESULT STDMETHODCALLTYPE GetDesc(D3DINDEXBUFFER_DESC *pDesc) override;
 
 private:
 	Direct3DDevice8 *const Device;

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -46,11 +46,11 @@ HRESULT STDMETHODCALLTYPE Direct3D8::QueryInterface(REFIID riid, void **ppvObj)
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3D8) ||
 		riid == __uuidof(IUnknown))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3D8 *>(this);
 
 		return S_OK;
 	}
@@ -166,7 +166,7 @@ HMONITOR STDMETHODCALLTYPE Direct3D8::GetAdapterMonitor(UINT Adapter)
 {
 	return ProxyInterface->GetAdapterMonitor(Adapter);
 }
-HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS8 *pPresentationParameters, Direct3DDevice8 **ppReturnedDeviceInterface)
+HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DDevice8 **ppReturnedDeviceInterface)
 {
 #ifndef D3D8TO9NOLOG
 	LOG << "Redirecting '" << "IDirect3D8::CreateDevice" << "(" << this << ", " << Adapter << ", " << DeviceType << ", " << hFocusWindow << ", " << BehaviorFlags << ", " << pPresentationParameters << ", " << ppReturnedDeviceInterface << ")' ..." << std::endl;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -30,11 +30,11 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::QueryInterface(REFIID riid, void **pp
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DDevice8) ||
 		riid == __uuidof(IUnknown))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DDevice8 *>(this);
 
 		return S_OK;
 	}
@@ -73,7 +73,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::ResourceManagerDiscardBytes(DWORD Byt
 
 	return ProxyInterface->EvictManagedResources();
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetDirect3D(Direct3D8 **ppD3D8)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetDirect3D(IDirect3D8 **ppD3D8)
 {
 	if (ppD3D8 == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -106,12 +106,13 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetCreationParameters(D3DDEVICE_CREAT
 {
 	return ProxyInterface->GetCreationParameters(pParameters);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetCursorProperties(UINT XHotSpot, UINT YHotSpot, Direct3DSurface8 *pCursorBitmap)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetCursorProperties(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface8 *pCursorBitmap)
 {
 	if (pCursorBitmap == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	return ProxyInterface->SetCursorProperties(XHotSpot, YHotSpot, pCursorBitmap->GetProxyInterface());
+	auto pCursorBitmapImpl = static_cast<Direct3DSurface8 *>(pCursorBitmap);
+	return ProxyInterface->SetCursorProperties(XHotSpot, YHotSpot, pCursorBitmapImpl->GetProxyInterface());
 }
 void STDMETHODCALLTYPE Direct3DDevice8::SetCursorPosition(UINT XScreenSpace, UINT YScreenSpace, DWORD Flags)
 {
@@ -121,7 +122,7 @@ BOOL STDMETHODCALLTYPE Direct3DDevice8::ShowCursor(BOOL bShow)
 {
 	return ProxyInterface->ShowCursor(bShow);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS8 *pPresentationParameters, Direct3DSwapChain8 **ppSwapChain)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS8 *pPresentationParameters, IDirect3DSwapChain8 **ppSwapChain)
 {
 #ifndef D3D8TO9NOLOG
 	LOG << "Redirecting '" << "IDirect3DDevice8::CreateAdditionalSwapChain" << "(" << this << ", " << pPresentationParameters << ", " << ppSwapChain << ")' ..." << std::endl;
@@ -203,7 +204,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Present(const RECT *pSourceRect, cons
 
 	return ProxyInterface->Present(pSourceRect, pDestRect, hDestWindowOverride, nullptr);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, Direct3DSurface8 **ppBackBuffer)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer)
 {
 	if (ppBackBuffer == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -232,7 +233,7 @@ void STDMETHODCALLTYPE Direct3DDevice8::GetGammaRamp(D3DGAMMARAMP *pRamp)
 {
 	ProxyInterface->GetGammaRamp(0, pRamp);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DTexture8 **ppTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture8 **ppTexture)
 {
 	if (ppTexture == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -265,7 +266,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateTexture(UINT Width, UINT Height
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DVolumeTexture8 **ppVolumeTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture8 **ppVolumeTexture)
 {
 	if (ppVolumeTexture == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -282,7 +283,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVolumeTexture(UINT Width, UINT 
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DCubeTexture8 **ppCubeTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture8 **ppCubeTexture)
 {
 	if (ppCubeTexture == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -299,7 +300,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateCubeTexture(UINT EdgeLength, UI
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, Direct3DVertexBuffer8 **ppVertexBuffer)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer8 **ppVertexBuffer)
 {
 	if (ppVertexBuffer == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -316,7 +317,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexBuffer(UINT Length, DWORD
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, Direct3DIndexBuffer8 **ppIndexBuffer)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer8 **ppIndexBuffer)
 {
 	if (ppIndexBuffer == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -333,7 +334,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateIndexBuffer(UINT Length, DWORD 
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable, Direct3DSurface8 **ppSurface)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable, IDirect3DSurface8 **ppSurface)
 {
 	if (ppSurface == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -362,7 +363,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, Direct3DSurface8 **ppSurface)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, IDirect3DSurface8 **ppSurface)
 {
 	if (ppSurface == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -391,7 +392,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width,
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, Direct3DSurface8 **ppSurface)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, IDirect3DSurface8 **ppSurface)
 {
 #ifndef D3D8TO9NOLOG
 	LOG << "Redirecting '" << "IDirect3DDevice8::CreateImageSurface" << "(" << this << ", " << Width << ", " << Height << ", " << Format << ", " << ppSurface << ")' ..." << std::endl;
@@ -426,14 +427,17 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT H
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(Direct3DSurface8 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects, Direct3DSurface8 *pDestinationSurface, const POINT *pDestPointsArray)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(IDirect3DSurface8 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects, IDirect3DSurface8 *pDestinationSurface, const POINT *pDestPointsArray)
 {
 	if (pSourceSurface == nullptr || pDestinationSurface == nullptr || pSourceSurface == pDestinationSurface)
 		return D3DERR_INVALIDCALL;
 
+	auto pSourceSurfaceImpl = static_cast<Direct3DSurface8 *>(pSourceSurface);
+	auto pDestinationSurfaceImpl = static_cast<Direct3DSurface8 *>(pDestinationSurface);
+
 	D3DSURFACE_DESC SourceDesc, DestinationDesc;
-	pSourceSurface->GetProxyInterface()->GetDesc(&SourceDesc);
-	pDestinationSurface->GetProxyInterface()->GetDesc(&DestinationDesc);
+	pSourceSurfaceImpl->GetProxyInterface()->GetDesc(&SourceDesc);
+	pDestinationSurfaceImpl->GetProxyInterface()->GetDesc(&DestinationDesc);
 
 	if (SourceDesc.Format != DestinationDesc.Format)
 		return D3DERR_INVALIDCALL;
@@ -476,11 +480,11 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(Direct3DSurface8 *pSourceSu
 			hr = D3DERR_INVALIDCALL;
 			if (D3DXLoadSurfaceFromSurface != nullptr)
 			{
-				if (SUCCEEDED(D3DXLoadSurfaceFromSurface(pDestinationSurface->GetProxyInterface(), nullptr, &DestinationRect, pSourceSurface->GetProxyInterface(), nullptr, &SourceRect, D3DX_FILTER_NONE, 0)))
+				if (SUCCEEDED(D3DXLoadSurfaceFromSurface(pDestinationSurfaceImpl->GetProxyInterface(), nullptr, &DestinationRect, pSourceSurfaceImpl->GetProxyInterface(), nullptr, &SourceRect, D3DX_FILTER_NONE, 0)))
 				{
 					// Explicitly call AddDirtyRect on the surface
 					void *pContainer = nullptr;
-					if (SUCCEEDED(pDestinationSurface->GetContainer(IID_IDirect3DTexture9, &pContainer)) && pContainer)
+					if (SUCCEEDED(pDestinationSurfaceImpl->GetContainer(IID_IDirect3DTexture9, &pContainer)) && pContainer)
 					{
 						IDirect3DTexture9 *pTexture = (IDirect3DTexture9*)pContainer;
 						pTexture->AddDirtyRect(&DestinationRect);
@@ -492,13 +496,13 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(Direct3DSurface8 *pSourceSu
 		}
 		else if (SourceDesc.Pool == D3DPOOL_DEFAULT)
 		{
-			hr = ProxyInterface->StretchRect(pSourceSurface->GetProxyInterface(), &SourceRect, pDestinationSurface->GetProxyInterface(), &DestinationRect, D3DTEXF_NONE);
+			hr = ProxyInterface->StretchRect(pSourceSurfaceImpl->GetProxyInterface(), &SourceRect, pDestinationSurfaceImpl->GetProxyInterface(), &DestinationRect, D3DTEXF_NONE);
 		}
 		else if (SourceDesc.Pool == D3DPOOL_SYSTEMMEM)
 		{
 			const POINT pt = { DestinationRect.left, DestinationRect.top };
 
-			hr = ProxyInterface->UpdateSurface(pSourceSurface->GetProxyInterface(), &SourceRect, pDestinationSurface->GetProxyInterface(), &pt);
+			hr = ProxyInterface->UpdateSurface(pSourceSurfaceImpl->GetProxyInterface(), &SourceRect, pDestinationSurfaceImpl->GetProxyInterface(), &pt);
 		}
 
 		if (FAILED(hr))
@@ -512,7 +516,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(Direct3DSurface8 *pSourceSu
 
 	return hr;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::UpdateTexture(Direct3DBaseTexture8 *pSourceTexture, Direct3DBaseTexture8 *pDestinationTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::UpdateTexture(IDirect3DBaseTexture8 *pSourceTexture, IDirect3DBaseTexture8 *pDestinationTexture)
 {
 	if (pSourceTexture == nullptr || pDestinationTexture == nullptr || pSourceTexture->GetType() != pDestinationTexture->GetType())
 		return D3DERR_INVALIDCALL;
@@ -539,29 +543,32 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::UpdateTexture(Direct3DBaseTexture8 *p
 
 	return ProxyInterface->UpdateTexture(SourceBaseTextureInterface, DestinationBaseTextureInterface);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetFrontBuffer(Direct3DSurface8 *pDestSurface)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetFrontBuffer(IDirect3DSurface8 *pDestSurface)
 {
 	if (pDestSurface == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	return ProxyInterface->GetFrontBufferData(0, pDestSurface->GetProxyInterface());
+	auto pDestSurfaceImpl = static_cast<Direct3DSurface8 *>(pDestSurface);
+	return ProxyInterface->GetFrontBufferData(0, pDestSurfaceImpl->GetProxyInterface());
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(Direct3DSurface8 *pRenderTarget, Direct3DSurface8 *pNewZStencil)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(IDirect3DSurface8 *pRenderTarget, IDirect3DSurface8 *pNewZStencil)
 {
 	HRESULT hr;
 
 	if (pRenderTarget != nullptr)
 	{
-		hr = ProxyInterface->SetRenderTarget(0, pRenderTarget->GetProxyInterface());
+		auto pRenderTargetImpl = static_cast<Direct3DSurface8 *>(pRenderTarget);
+		hr = ProxyInterface->SetRenderTarget(0, pRenderTargetImpl->GetProxyInterface());
 		if (FAILED(hr))
 			return hr;
 
-		pCurrentRenderTarget = pRenderTarget->GetProxyInterface();
+		pCurrentRenderTarget = pRenderTargetImpl->GetProxyInterface();
 	}
 
 	if (pNewZStencil != nullptr)
 	{
-		hr = ProxyInterface->SetDepthStencilSurface(pNewZStencil->GetProxyInterface());
+		auto pNewZStencilImpl = static_cast<Direct3DSurface8 *>(pNewZStencil);
+		hr = ProxyInterface->SetDepthStencilSurface(pNewZStencilImpl->GetProxyInterface());
 		if (FAILED(hr))
 			return hr;
 	}
@@ -572,7 +579,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(Direct3DSurface8 *pRe
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderTarget(Direct3DSurface8 **ppRenderTarget)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderTarget(IDirect3DSurface8 **ppRenderTarget)
 {
 	if (ppRenderTarget == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -589,7 +596,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderTarget(Direct3DSurface8 **pp
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetDepthStencilSurface(Direct3DSurface8 **ppZStencilSurface)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetDepthStencilSurface(IDirect3DSurface8 **ppZStencilSurface)
 {
 	if (ppZStencilSurface == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -706,7 +713,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderState(D3DRENDERSTATETYPE Sta
 		return hr;
 	case D3DRS_ZBIAS:
 		Biased = static_cast<FLOAT>(Value) * -0.000005f;
-		Value = *reinterpret_cast<const DWORD *>(&Biased);
+		memcpy(&Value, &Biased, sizeof(Value));
 		State = D3DRS_DEPTHBIAS;
 	default:
 		return ProxyInterface->SetRenderState(State, Value);
@@ -796,7 +803,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetClipStatus(D3DCLIPSTATUS8 *pClipSt
 {
 	return ProxyInterface->GetClipStatus(pClipStatus);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, Direct3DBaseTexture8 **ppTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, IDirect3DBaseTexture8 **ppTexture)
 {
 	if (ppTexture == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -836,7 +843,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, Direct3DBaseT
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetTexture(DWORD Stage, Direct3DBaseTexture8 *pTexture)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetTexture(DWORD Stage, IDirect3DBaseTexture8 *pTexture)
 {
 	if (pTexture == nullptr)
 		return ProxyInterface->SetTexture(Stage, nullptr);
@@ -980,12 +987,13 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::DrawIndexedPrimitiveUP(D3DPRIMITIVETY
 	ApplyClipPlanes();
 	return ProxyInterface->DrawIndexedPrimitiveUP(PrimitiveType, MinVertexIndex, NumVertexIndices, PrimitiveCount, pIndexData, IndexDataFormat, pVertexStreamZeroData, VertexStreamZeroStride);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, Direct3DVertexBuffer8 *pDestBuffer, DWORD Flags)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer8 *pDestBuffer, DWORD Flags)
 {
 	if (pDestBuffer == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	return ProxyInterface->ProcessVertices(SrcStartIndex, DestIndex, VertexCount, pDestBuffer->GetProxyInterface(), nullptr, Flags);
+	Direct3DVertexBuffer8 *pDestBufferImpl = static_cast<Direct3DVertexBuffer8 *>(pDestBuffer);
+	return ProxyInterface->ProcessVertices(SrcStartIndex, DestIndex, VertexCount, pDestBufferImpl->GetProxyInterface(), nullptr, Flags);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexShader(const DWORD *pDeclaration, const DWORD *pFunction, DWORD *pHandle, DWORD Usage)
 {
@@ -1539,14 +1547,15 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetVertexShaderFunction(DWORD Handle,
 
 	return VertexShaderInterface->GetFunction(pData, reinterpret_cast<UINT *>(pSizeOfData));
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetStreamSource(UINT StreamNumber, Direct3DVertexBuffer8 *pStreamData, UINT Stride)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 *pStreamData, UINT Stride)
 {
 	if (pStreamData == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	return ProxyInterface->SetStreamSource(StreamNumber, pStreamData->GetProxyInterface(), 0, Stride);
+	auto pStreamDataImpl = static_cast<Direct3DVertexBuffer8 *>(pStreamData);
+	return ProxyInterface->SetStreamSource(StreamNumber, pStreamDataImpl->GetProxyInterface(), 0, Stride);
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetStreamSource(UINT StreamNumber, Direct3DVertexBuffer8 **ppStreamData, UINT *pStride)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 **ppStreamData, UINT *pStride)
 {
 	if (ppStreamData == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -1565,16 +1574,17 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetStreamSource(UINT StreamNumber, Di
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetIndices(Direct3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetIndices(IDirect3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex)
 {
 	if (pIndexData == nullptr || BaseVertexIndex > 0x7FFFFFFF)
 		return D3DERR_INVALIDCALL;
 
 	CurrentBaseVertexIndex = static_cast<INT>(BaseVertexIndex);
 
-	return ProxyInterface->SetIndices(pIndexData->GetProxyInterface());
+	auto pIndexDataImpl = static_cast<Direct3DIndexBuffer8 *>(pIndexData);
+	return ProxyInterface->SetIndices(pIndexDataImpl->GetProxyInterface());
 }
-HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetIndices(Direct3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex)
+HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetIndices(IDirect3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex)
 {
 	if (ppIndexData == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_index_buffer.cpp
+++ b/source/d3d8to9_index_buffer.cpp
@@ -19,12 +19,12 @@ HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::QueryInterface(REFIID riid, void
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DIndexBuffer8) ||
 		riid == __uuidof(IUnknown) ||
-		riid == __uuidof(Direct3DResource8))
+		riid == __uuidof(IDirect3DResource8))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DIndexBuffer8 *>(this);
 
 		return S_OK;
 	}
@@ -44,7 +44,7 @@ ULONG STDMETHODCALLTYPE Direct3DIndexBuffer8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DIndexBuffer8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_surface.cpp
+++ b/source/d3d8to9_surface.cpp
@@ -19,11 +19,11 @@ HRESULT STDMETHODCALLTYPE Direct3DSurface8::QueryInterface(REFIID riid, void **p
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DSurface8) ||
 		riid == __uuidof(IUnknown))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DSurface8 *>(this);
 
 		return S_OK;
 	}
@@ -43,7 +43,7 @@ ULONG STDMETHODCALLTYPE Direct3DSurface8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DSurface8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DSurface8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_swap_chain.cpp
+++ b/source/d3d8to9_swap_chain.cpp
@@ -19,11 +19,11 @@ HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::QueryInterface(REFIID riid, void *
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DSwapChain8) ||
 		riid == __uuidof(IUnknown))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DSwapChain8 *>(this);
 
 		return S_OK;
 	}
@@ -49,7 +49,7 @@ HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::Present(const RECT *pSourceRect, c
 
 	return ProxyInterface->Present(pSourceRect, pDestRect, hDestWindowOverride, nullptr, 0);
 }
-HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, Direct3DSurface8 **ppBackBuffer)
+HRESULT STDMETHODCALLTYPE Direct3DSwapChain8::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface8 **ppBackBuffer)
 {
 	if (ppBackBuffer == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_texture.cpp
+++ b/source/d3d8to9_texture.cpp
@@ -19,13 +19,13 @@ HRESULT STDMETHODCALLTYPE Direct3DTexture8::QueryInterface(REFIID riid, void **p
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DTexture8) ||
 		riid == __uuidof(IUnknown) ||
-		riid == __uuidof(Direct3DResource8) ||
-		riid == __uuidof(Direct3DBaseTexture8))
+		riid == __uuidof(IDirect3DResource8) ||
+		riid == __uuidof(IDirect3DBaseTexture8))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DTexture8 *>(this);
 
 		return S_OK;
 	}
@@ -45,7 +45,7 @@ ULONG STDMETHODCALLTYPE Direct3DTexture8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -112,7 +112,7 @@ HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetLevelDesc(UINT Level, D3DSURFACE_
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetSurfaceLevel(UINT Level, Direct3DSurface8 **ppSurfaceLevel)
+HRESULT STDMETHODCALLTYPE Direct3DTexture8::GetSurfaceLevel(UINT Level, IDirect3DSurface8 **ppSurfaceLevel)
 {
 	if (ppSurfaceLevel == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -157,13 +157,13 @@ HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::QueryInterface(REFIID riid, void
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DCubeTexture8) ||
 		riid == __uuidof(IUnknown) ||
-		riid == __uuidof(Direct3DResource8) ||
-		riid == __uuidof(Direct3DBaseTexture8))
+		riid == __uuidof(IDirect3DResource8) ||
+		riid == __uuidof(IDirect3DBaseTexture8))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DCubeTexture8 *>(this);
 
 		return S_OK;
 	}
@@ -183,7 +183,7 @@ ULONG STDMETHODCALLTYPE Direct3DCubeTexture8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -250,7 +250,7 @@ HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetLevelDesc(UINT Level, D3DSURF
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetCubeMapSurface(D3DCUBEMAP_FACES FaceType, UINT Level, Direct3DSurface8 **ppCubeMapSurface)
+HRESULT STDMETHODCALLTYPE Direct3DCubeTexture8::GetCubeMapSurface(D3DCUBEMAP_FACES FaceType, UINT Level, IDirect3DSurface8 **ppCubeMapSurface)
 {
 	if (ppCubeMapSurface == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -295,13 +295,13 @@ HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::QueryInterface(REFIID riid, vo
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DVolumeTexture8) ||
 		riid == __uuidof(IUnknown) ||
-		riid == __uuidof(Direct3DResource8) ||
-		riid == __uuidof(Direct3DBaseTexture8))
+		riid == __uuidof(IDirect3DResource8) ||
+		riid == __uuidof(IDirect3DBaseTexture8))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DVolumeTexture8 *>(this);
 
 		return S_OK;
 	}
@@ -321,7 +321,7 @@ ULONG STDMETHODCALLTYPE Direct3DVolumeTexture8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;
@@ -388,7 +388,7 @@ HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetLevelDesc(UINT Level, D3DVO
 
 	return D3D_OK;
 }
-HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetVolumeLevel(UINT Level, Direct3DVolume8 **ppVolumeLevel)
+HRESULT STDMETHODCALLTYPE Direct3DVolumeTexture8::GetVolumeLevel(UINT Level, IDirect3DVolume8 **ppVolumeLevel)
 {
 	if (ppVolumeLevel == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_vertex_buffer.cpp
+++ b/source/d3d8to9_vertex_buffer.cpp
@@ -19,12 +19,12 @@ HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::QueryInterface(REFIID riid, voi
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DVertexBuffer8) ||
 		riid == __uuidof(IUnknown) ||
-		riid == __uuidof(Direct3DResource8))
+		riid == __uuidof(IDirect3DResource8))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DVertexBuffer8 *>(this);
 
 		return S_OK;
 	}
@@ -44,7 +44,7 @@ ULONG STDMETHODCALLTYPE Direct3DVertexBuffer8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DVertexBuffer8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_volume.cpp
+++ b/source/d3d8to9_volume.cpp
@@ -19,11 +19,11 @@ HRESULT STDMETHODCALLTYPE Direct3DVolume8::QueryInterface(REFIID riid, void **pp
 	if (ppvObj == nullptr)
 		return E_POINTER;
 
-	if (riid == __uuidof(this) ||
+	if (riid == __uuidof(IDirect3DVolume8) ||
 		riid == __uuidof(IUnknown))
 	{
 		AddRef();
-		*ppvObj = this;
+		*ppvObj = static_cast<IDirect3DVolume8 *>(this);
 
 		return S_OK;
 	}
@@ -43,7 +43,7 @@ ULONG STDMETHODCALLTYPE Direct3DVolume8::Release()
 	return ProxyInterface->Release();
 }
 
-HRESULT STDMETHODCALLTYPE Direct3DVolume8::GetDevice(Direct3DDevice8 **ppDevice)
+HRESULT STDMETHODCALLTYPE Direct3DVolume8::GetDevice(IDirect3DDevice8 **ppDevice)
 {
 	if (ppDevice == nullptr)
 		return D3DERR_INVALIDCALL;

--- a/source/interface_query.cpp
+++ b/source/interface_query.cpp
@@ -18,9 +18,9 @@ void GenericQueryInterface(REFIID riid, LPVOID *ppvObj, Direct3DDevice8 *pDevice
 	if (ppvObj == nullptr || *ppvObj == nullptr || pDevice == nullptr)
 		return;
 
-	if (riid == __uuidof(Direct3D8))
+	if (riid == __uuidof(IDirect3D8))
 	{
-		Direct3D8 *pD3D8 = nullptr;
+		IDirect3D8 *pD3D8 = nullptr;
 		if (SUCCEEDED(pDevice->GetDirect3D(&pD3D8)) && pD3D8)
 		{
 			*ppvObj = pD3D8;
@@ -29,14 +29,14 @@ void GenericQueryInterface(REFIID riid, LPVOID *ppvObj, Direct3DDevice8 *pDevice
 		}
 	}
 
-	if (riid == __uuidof(Direct3DDevice8))
+	if (riid == __uuidof(IDirect3DDevice8))
 	{
-		*ppvObj = pDevice;
+		*ppvObj = static_cast<IDirect3DDevice8 *>(pDevice);
 		return;
 	}
 
 #define QUERY_INTERFACE(x) \
-	if (riid == __uuidof(x)) \
+	if (riid == __uuidof(I ## x)) \
 	{ \
 		*ppvObj = pDevice->ProxyAddressLookupTable->FindAddress<x>(*ppvObj); \
 		return; \
@@ -54,25 +54,25 @@ void GenericQueryInterface(REFIID riid, LPVOID *ppvObj, Direct3DDevice8 *pDevice
 
 REFIID ConvertREFIID(REFIID riid)
 {
-	if (riid == __uuidof(Direct3D8))
+	if (riid == __uuidof(IDirect3D8))
 		return IID_IDirect3D9;
-	if (riid == __uuidof(Direct3DDevice8))
+	if (riid == __uuidof(IDirect3DDevice8))
 		return IID_IDirect3DDevice9;
-	if (riid == __uuidof(Direct3DTexture8))
+	if (riid == __uuidof(IDirect3DTexture8))
 		return IID_IDirect3DTexture9;
-	if (riid == __uuidof(Direct3DCubeTexture8))
+	if (riid == __uuidof(IDirect3DCubeTexture8))
 		return IID_IDirect3DCubeTexture9;
-	if (riid == __uuidof(Direct3DVolumeTexture8))
+	if (riid == __uuidof(IDirect3DVolumeTexture8))
 		return IID_IDirect3DVolumeTexture9;
-	if (riid == __uuidof(Direct3DVertexBuffer8))
+	if (riid == __uuidof(IDirect3DVertexBuffer8))
 		return IID_IDirect3DVertexBuffer9;
-	if (riid == __uuidof(Direct3DIndexBuffer8))
+	if (riid == __uuidof(IDirect3DIndexBuffer8))
 		return IID_IDirect3DIndexBuffer9;
-	if (riid == __uuidof(Direct3DSurface8))
+	if (riid == __uuidof(IDirect3DSurface8))
 		return IID_IDirect3DSurface9;
-	if (riid == __uuidof(Direct3DVolume8))
+	if (riid == __uuidof(IDirect3DVolume8))
 		return IID_IDirect3DVolume9;
-	if (riid == __uuidof(Direct3DSwapChain8))
+	if (riid == __uuidof(IDirect3DSwapChain8))
 		return IID_IDirect3DSwapChain9;
 	return riid;
 }

--- a/source/interface_query.hpp
+++ b/source/interface_query.hpp
@@ -8,6 +8,17 @@
 #include <algorithm>
 #include <unordered_map>
 
+class Direct3D8;
+class Direct3DDevice8;
+class Direct3DSwapChain8;
+class Direct3DTexture8;
+class Direct3DCubeTexture8;
+class Direct3DVolumeTexture8;
+class Direct3DSurface8;
+class Direct3DVolume8;
+class Direct3DVertexBuffer8;
+class Direct3DIndexBuffer8;
+
 class AddressLookupTable
 {
 	template <typename T>


### PR DESCRIPTION
Virtual function tables were not matching d3d8 because destructor pointer was inserted at offset 0. I wonder how this can work in MSVC...