### PR TITLE
Shader lifetime improvement

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_set>
 #include "d3d8.hpp"
 #include "interface_query.hpp"
 
@@ -160,6 +161,7 @@ public:
 
 private:
 	void ApplyClipPlanes();
+	void ReleaseShaders();
 
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
@@ -172,6 +174,9 @@ private:
 	static constexpr size_t MAX_CLIP_PLANES = 6;
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};
 	DWORD ClipPlaneRenderState = 0;
+
+	// Store Shader Handles so they can be destroyed later to mirror D3D8 behavior 
+	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles;
 };
 
 class Direct3DSwapChain8 : public IDirect3DSwapChain8, public AddressLookupTableObject

--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -177,6 +177,7 @@ private:
 
 	// Store Shader Handles so they can be destroyed later to mirror D3D8 behavior 
 	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles;
+	unsigned int VertexShaderAndDeclarationCount = 0;
 };
 
 class Direct3DSwapChain8 : public IDirect3DSwapChain8, public AddressLookupTableObject

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1526,7 +1526,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::DeleteVertexShader(DWORD Handle)
 	const DWORD HandleMagic = Handle << 1;
 	VertexShaderInfo *const ShaderInfo = reinterpret_cast<VertexShaderInfo *>(HandleMagic);
 
-	if (ShaderInfo->Shader != nullptr) {
+	if (ShaderInfo->Shader != nullptr) 
+	{
 		ShaderInfo->Shader->Release();
 		VertexShaderHandles.erase(reinterpret_cast<DWORD>(ShaderInfo->Shader));
 	}


### PR DESCRIPTION
This is a proposal to fix the issue outlined in https://github.com/crosire/d3d8to9/issues/155. Basically, D3D8.1 and D3D9 lifetimes have different rules but d3d8to9 currently doesn't follow the D3D8.1 behavior (which is that shaders share a lifetime with the device that created them and are implicitly destroyed). This causes some D3D8 applications to leak shader and device objects even if they are well behaved under plain D3D8.x.

Here is a test that shows this behavior:
[d3d8_refcounttest.zip](https://github.com/crosire/d3d8to9/files/11711248/d3d8_refcounttest.zip)
