### PR TITLE
Revert the call to ReleaseShaders in Device::Reset.

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -207,10 +207,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 		}
 	}
 
-	// Shaders are destroyed alongside the device that created them in D3D8 but not in D3D9
-	// so we Release all the shaders when the device releases to mirror that behaviour
-	ReleaseShaders();
-
 	return ProxyInterface->Reset(&PresentParams);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion)


### PR DESCRIPTION
Related to #159 , it seems that some D3D8 applications will still make calls to SetVertexShader() after a Present call returns D3DERR_DEVICELOST and the device is lost. The Microsoft documentation mentioned in #155 seems to imply otherwise, but the Microsoft supplied d3d8dll seems to handle this case just fine so applications for DX8 probably just followed this behavior at the time. I am retaining the shader destruction on device release though, since in testing of d3d8.dll, shader objects don't increment the device refcount and this was causing d3d9 devices and shaders to leak under d3d8to9. 