### PR TITLE
Take viewport X & Y coordinates into account during validation

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -652,7 +652,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetViewport(const D3DVIEWPORT8 *pView
 	{
 		D3DSURFACE_DESC Desc;
 
-		if (SUCCEEDED(pCurrentRenderTarget->GetDesc(&Desc)) && (pViewport->Height > Desc.Height || pViewport->Width > Desc.Width))
+		if (SUCCEEDED(pCurrentRenderTarget->GetDesc(&Desc)) && (pViewport->Y + pViewport->Height > Desc.Height || pViewport->X + pViewport->Width > Desc.Width))
 			return D3DERR_INVALIDCALL;
 	}
 


### PR DESCRIPTION
The viewport validation done during SetViewport() should take the X & Y coordinates into account (situations where the viewport dimensions are smaller than the render target dimensions, but the X or Y offsets are so great that the viewport still ends up outside the render target).

[I wrote a test](https://github.com/WinterSnowfall/d8vk-tests/blob/f94030adefdbe9a3e06a2c62e29584e88be39b6b/d3d8/d3d8_triangle.cpp#L824) for this and verified it passes on native d3d8.