### PR TITLE
Fix resource leak and prevent pure device creation

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -197,7 +197,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	IDirect3DDevice9 *DeviceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
+	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags & ~D3DCREATE_PUREDEVICE, &PresentParams, &DeviceInterface);
 	if (FAILED(hr))
 		return hr;
 

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -197,7 +197,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 
 	IDirect3DDevice9 *DeviceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags & ~D3DCREATE_PUREDEVICE, &PresentParams, &DeviceInterface);
+	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);
 	if (FAILED(hr))
 		return hr;
 

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -851,14 +851,17 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, IDirect3DBase
 		case D3DRTYPE_TEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&TextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DTexture8>(TextureInterface);
+			TextureInterface->Release();
 			break;
 		case D3DRTYPE_VOLUMETEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&VolumeTextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DVolumeTexture8>(VolumeTextureInterface);
+			VolumeTextureInterface->Release();
 			break;
 		case D3DRTYPE_CUBETEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&CubeTextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DCubeTexture8>(CubeTextureInterface);
+			CubeTextureInterface->Release();
 			break;
 		default:
 			return D3DERR_INVALIDCALL;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -851,19 +851,20 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetTexture(DWORD Stage, IDirect3DBase
 		case D3DRTYPE_TEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&TextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DTexture8>(TextureInterface);
-			TextureInterface->Release();
+			BaseTextureInterface->Release();
 			break;
 		case D3DRTYPE_VOLUMETEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&VolumeTextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DVolumeTexture8>(VolumeTextureInterface);
-			VolumeTextureInterface->Release();
+			BaseTextureInterface->Release();
 			break;
 		case D3DRTYPE_CUBETEXTURE:
 			BaseTextureInterface->QueryInterface(IID_PPV_ARGS(&CubeTextureInterface));
 			*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DCubeTexture8>(CubeTextureInterface);
-			CubeTextureInterface->Release();
+			BaseTextureInterface->Release();
 			break;
 		default:
+			BaseTextureInterface->Release();
 			return D3DERR_INVALIDCALL;
 		}
 	}


### PR DESCRIPTION
This fixes a resource leak that happens in `GetTexture()` because we query for the interface after getting the texture and never release the extra reference that creates.

Also, this prevents the game from creating a pure device.  d3d8to9 won't work with a pure device because it requires many `Get` functions that won't work if a game creates a pure device.