### PR TITLE
Track and release state blocks on device release

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -161,7 +161,7 @@ public:
 
 private:
 	void ApplyClipPlanes();
-	void ReleaseShaders();
+	void ReleaseShadersAndStateBlocks();
 
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
@@ -175,8 +175,8 @@ private:
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};
 	DWORD ClipPlaneRenderState = 0;
 
-	// Store Shader Handles so they can be destroyed later to mirror D3D8 behavior 
-	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles;
+	// Store Shader Handles and State Block Tokens so they can be destroyed later to mirror D3D8 behavior
+	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles, StateBlockTokens;
 	unsigned int VertexShaderAndDeclarationCount = 0;
 };
 


### PR DESCRIPTION
Similarly to VS, shader definitions and PS, some games create state blocks that they never delete and expect the D3D8 runtime to perform this cleanup on device release (this doesn't happen in D3D9). Should help improve, if not completely address #92, but needs some wider testing.