### PR TITLE
Remove CreateImageSurface R8G8B8 swap with X8R8G8B

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -414,14 +414,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT H
 
 	*ppSurface = nullptr;
 
-	if (Format == D3DFMT_R8G8B8)
-	{
-#ifndef D3D8TO9NOLOG
-		LOG << "> Replacing format 'D3DFMT_R8G8B8' with 'D3DFMT_X8R8G8B8' ..." << std::endl;
-#endif
-		Format = D3DFMT_X8R8G8B8;
-	}
-
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
 	const HRESULT hr = ProxyInterface->CreateOffscreenPlainSurface(Width, Height, Format, D3DPOOL_SYSTEMMEM, &SurfaceInterface, nullptr);


### PR DESCRIPTION
I'm guessing this format swap is a remnant from the initial code, if git blame is to be believed. It should no longer be needed now, as image surfaces with R8G8B8 will be created just fine in D3DPOOL_SCRATCH, with the current fallback logic.

The swap usually works fine anyway, but has the drawback of causing minor issues at times, such as corrupting savegame screenshots in [Chrome](https://www.pcgamingwiki.com/wiki/Chrome). Keeping R8G8B8 as is solves this problem.