### PR TITLE
Validate depth formats on use with CopyRects

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -445,6 +445,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CopyRects(IDirect3DSurface8 *pSourceS
 	if (SourceDesc.Format != DestinationDesc.Format)
 		return D3DERR_INVALIDCALL;
 
+	if (IsDepthStencil(SourceDesc.Format))
+		return D3DERR_INVALIDCALL;
+
 	HRESULT hr = D3DERR_INVALIDCALL;
 
 	if (cRects == 0)

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -15,6 +15,16 @@ bool SupportsPalettes()
 	return hasPalette;
 }
 
+bool IsDepthStencil(D3DFORMAT &Format) {
+	return Format == D3DFMT_D16_LOCKABLE
+		|| Format == D3DFMT_D16
+		|| Format == D3DFMT_D32
+		|| Format == D3DFMT_D15S1
+		|| Format == D3DFMT_D24X4S4
+		|| Format == D3DFMT_D24S8
+		|| Format == D3DFMT_D24X8;
+}
+
 static UINT CalcTextureSize(UINT Width, UINT Height, UINT Depth, D3DFORMAT Format)
 {
 	switch (static_cast<DWORD>(Format))

--- a/source/d3d8types.hpp
+++ b/source/d3d8types.hpp
@@ -172,6 +172,7 @@ struct D3DADAPTER_IDENTIFIER8
 };
 
 bool SupportsPalettes();
+bool IsDepthStencil(D3DFORMAT &format);
 
 void ConvertCaps(D3DCAPS9 &input, D3DCAPS8 &output);
 void ConvertVolumeDesc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output);


### PR DESCRIPTION
The D3D8 specs also say, with regards to CopyRects:

> This method cannot be applied to surfaces whose formats are classified as depth stencil formats.

I have checked this claim against native drivers and they do indeed validate it.