### PR TITLE
Reference count fix for Shaders and StateBlocks to prevent a crash when exiting games

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <vector>
-#include <unordered_set>
 #include "d3d8.hpp"
 #include "interface_query.hpp"
 
@@ -161,7 +160,6 @@ public:
 
 private:
 	void ApplyClipPlanes();
-	void ReleaseShadersAndStateBlocks();
 
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
@@ -175,9 +173,8 @@ private:
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};
 	DWORD ClipPlaneRenderState = 0;
 
-	// Store Shader Handles and State Block Tokens so they can be destroyed later to mirror D3D8 behavior
-	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles, StateBlockTokens;
-	unsigned int VertexShaderAndDeclarationCount = 0;
+	// Shaders and state blocks are counted in d3d9 but not in d3d8
+	unsigned int StateBlockCount = 0, PixelShaderCount = 0, VertexShaderAndDeclarationCount = 0;
 };
 
 class Direct3DSwapChain8 : public IDirect3DSwapChain8, public AddressLookupTableObject

--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_set>
 #include "d3d8.hpp"
 #include "interface_query.hpp"
 
@@ -160,6 +161,7 @@ public:
 
 private:
 	void ApplyClipPlanes();
+	void ReleaseShadersAndStateBlocks();
 
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
@@ -173,8 +175,9 @@ private:
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};
 	DWORD ClipPlaneRenderState = 0;
 
-	// Shaders and state blocks are counted in d3d9 but not in d3d8
-	unsigned int StateBlockCount = 0, PixelShaderCount = 0, VertexShaderAndDeclarationCount = 0;
+	// Store Shader Handles and State Block Tokens so they can be destroyed later to mirror D3D8 behavior
+	std::unordered_set<DWORD> PixelShaderHandles, VertexShaderHandles, StateBlockTokens;
+	unsigned int VertexShaderAndDeclarationCount = 0;
 };
 
 class Direct3DSwapChain8 : public IDirect3DSwapChain8, public AddressLookupTableObject

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -2223,7 +2223,7 @@ void Direct3DDevice8::ReleaseShadersAndStateBlocks()
 	VertexShaderAndDeclarationCount = 0;
 	while (!StateBlockTokens.empty())
 	{
-		DWORD Token = *VertexShaderHandles.begin();
+		DWORD Token = *StateBlockTokens.begin();
 		DeleteStateBlock(Token);
 	}
 }

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -2210,21 +2210,20 @@ void Direct3DDevice8::ApplyClipPlanes()
 
 void Direct3DDevice8::ReleaseShadersAndStateBlocks()
 {
-	// Since DeletePixelShader, [...] each erases the handle from the unordered set we need to use a temporary set
-	std::unordered_set<DWORD> tmpPixelShaderHandles = std::move(PixelShaderHandles);
-	for (auto Handle : tmpPixelShaderHandles)
+	while (!PixelShaderHandles.empty())
 	{
+		DWORD Handle = *PixelShaderHandles.begin();
 		DeletePixelShader(Handle);
 	}
-	std::unordered_set<DWORD> tmpVertexShaderHandles = std::move(VertexShaderHandles);
-	for (auto Handle : tmpVertexShaderHandles)
+	while (!VertexShaderHandles.empty())
 	{
+		DWORD Handle = *VertexShaderHandles.begin();
 		DeleteVertexShader(Handle);
 	}
-	std::unordered_set<DWORD> tmpStateBlockTokens = std::move(StateBlockTokens);
 	VertexShaderAndDeclarationCount = 0;
-	for (auto Token : tmpStateBlockTokens)
+	while (!StateBlockTokens.empty())
 	{
+		DWORD Token = *VertexShaderHandles.begin();
 		DeleteStateBlock(Token);
 	}
 }

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -792,7 +792,12 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::EndStateBlock(DWORD *pToken)
 	if (pToken == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	return ProxyInterface->EndStateBlock(reinterpret_cast<IDirect3DStateBlock9 **>(pToken));
+	HRESULT hr = ProxyInterface->EndStateBlock(reinterpret_cast<IDirect3DStateBlock9**>(pToken));
+
+	if (SUCCEEDED(hr))
+		StateBlockTokens.insert(*pToken);
+
+	return hr;
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::ApplyStateBlock(DWORD Token)
 {


### PR DESCRIPTION
This will fix PR #159 so shaders and state blocks are correctly released once the device reference count reaches 1.  The previous code would cause a crash on exit in a couple of games, including _Indiana Jones and the Emperor's Tomb_ and _[State of Emergency](https://github.com/elishacloud/dxwrapper/issues/254#issuecomment-2372713179)_.

This fix does the following things:

1. It fixes the ref count issue in both `AddRef()` and `Release()` to return the correct value based on how the native Direct3D8 works.
2. It cleans up some code related to the shader count in `CreateVertexShader()`
3. It fixes a crash in Windows 7 64bit caused by erasing an item in a map while looping through the same map.

I tested this with a couple of games alongside the native d3d8 to ensure it does not crash and it works the same as the native d3d8.

_Note: it appears that you need to get the current device reference count by call `AddRef()` and then `Release()` before releasing the shaders and state blocks.  If you call `Release()` first then it can lead to a crash in some games._