### PR TITLE
Set the correct value of 0.0f for D3DRS_POINTSIZE_MIN

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -19,6 +19,10 @@ Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterfac
 {
 	ProxyAddressLookupTable = new AddressLookupTable(this);
 	PaletteFlag = SupportsPalettes();
+
+	// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
+	// whereas in D3D9 it is 1.0f, so adjust it as needed
+	ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
 }
 Direct3DDevice8::~Direct3DDevice8()
 {
@@ -224,7 +228,16 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 		}
 	}
 
-	return ProxyInterface->Reset(&PresentParams);
+	HRESULT hr = ProxyInterface->Reset(&PresentParams);
+
+	if (SUCCEEDED(hr))
+	{
+		// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
+		// whereas in D3D9 it is 1.0f, so adjust it as needed
+		ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
+	}
+
+	return hr;
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion)
 {


### PR DESCRIPTION
A minor nitpick, though some games may be affected by it in the end.

The default value of D3DRS_POINTSIZE_MIN in [D3D9 is 1.0f](https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3drenderstatetype#constants), whereas it is 0.0f in D3D8:

![image](https://github.com/user-attachments/assets/637bcc08-30ea-43c2-90a1-fd90455738a4)

This needs to be propagated both on device creation and on subsequent device resets.

Besides the documentation hinting at these defaults, I wrote a test to verify them against native d3d8 and d3d9, and they are indeed as stated (thus in need of correction).