### PR TITLE
Validate state block calls during state recording

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -170,6 +170,7 @@ private:
 	DWORD CurrentVertexShaderHandle = 0, CurrentPixelShaderHandle = 0;
 	IDirect3DSurface9 *pCurrentRenderTarget = nullptr;
 	bool PaletteFlag = false;
+	bool IsRecordingState = false;
 
 	static constexpr size_t MAX_CLIP_PLANES = 6;
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};


### PR DESCRIPTION
In D3D8 a call to `BeginStateBlock()` starts state recording and also causes other state block calls (with the exception of `EndStateBlock()`) to fail. D3D9 does not handle this state block call validation behavior automatically, since some calls such as `DeleteStateBlock()` are missing altogether.