### PR TITLE
Fix some char* assignment compiler warnings

### DIFF
--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -22,7 +22,7 @@ extern "C" HRESULT WINAPI ValidatePixelShader(const DWORD* pPixelShader, const D
 #endif
 
 	HRESULT hr = E_FAIL;
-	char* errorMessage = "";
+	const char* errorMessage = "";
 
 	if (!pPixelShader)
 	{
@@ -78,7 +78,7 @@ extern "C" HRESULT WINAPI ValidateVertexShader(const DWORD* pVertexShader, const
 #endif
 
 	HRESULT hr = E_FAIL;
-	char* errorMessage = "";
+	const char* errorMessage = "";
 
 	if (!pVertexShader)
 	{


### PR DESCRIPTION
Apparently using non-const char* causes warnings/errors with some C++ compilers, and this *should* be more palatable in general. @ThirteenAG Please let me know if this fixes the problem you were seeing.