### PR TITLE
Setup SWVP toggle for mixed mode devices

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -53,7 +53,7 @@ class Direct3DDevice8 : public IDirect3DDevice8
 	Direct3DDevice8 &operator=(const Direct3DDevice8 &) = delete;
 
 public:
-	Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, BOOL EnableZBufferDiscarding = FALSE);
+	Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, DWORD BehaviorFlags, BOOL EnableZBufferDiscarding = FALSE);
 	~Direct3DDevice8();
 
 	IDirect3DDevice9 *GetProxyInterface() const { return ProxyInterface; }
@@ -171,6 +171,7 @@ private:
 	IDirect3DSurface9 *pCurrentRenderTarget = nullptr;
 	bool PaletteFlag = false;
 	bool IsRecordingState = false;
+	bool IsMixedVPModeDevice = false;
 
 	static constexpr size_t MAX_CLIP_PLANES = 6;
 	float StoredClipPlanes[MAX_CLIP_PLANES][4] = {};

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -201,7 +201,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	if (FAILED(hr))
 		return hr;
 
-	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
+	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, BehaviorFlags, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	// Set default vertex declaration
 	DeviceInterface->SetFVF(D3DFVF_XYZ);


### PR DESCRIPTION
Not entirely sure why this wasn't being done in the first place, as devices created with D3DCREATE_MIXED_VERTEXPROCESSING expect this to work properly and there are some games that require dynamically switching between the two.

In the case of either D3DCREATE_SOFTWARE_VERTEXPROCESSING or D3DCREATE_HARDWARE_VERTEXPROCESSING devices, the call to `SetSoftwareVertexProcessing()` will simply fail, but we can safely ignore that. In fact D3D8 will never return anything other than D3D_OK for any `SetRenderState()` calls.