### PR TITLE
Revert clearing rect/volume content on surface/volume locks

### DIFF
--- a/source/d3d8to9_surface.cpp
+++ b/source/d3d8to9_surface.cpp
@@ -91,18 +91,6 @@ HRESULT STDMETHODCALLTYPE Direct3DSurface8::GetDesc(D3DSURFACE_DESC8 *pDesc)
 }
 HRESULT STDMETHODCALLTYPE Direct3DSurface8::LockRect(D3DLOCKED_RECT *pLockedRect, const RECT *pRect, DWORD Flags)
 {
-	D3DSURFACE_DESC8 SurfaceDesc;
-
-	const HRESULT hr = GetDesc(&SurfaceDesc);
-
-	// D3D8 clears the contents of pLockedRect for all
-	// surfaces except those of type D3DRTYPE_TEXTURE
-	if (SUCCEEDED(hr) && pLockedRect != nullptr && SurfaceDesc.Type != D3DRTYPE_TEXTURE)
-	{
-		pLockedRect->pBits = nullptr;
-		pLockedRect->Pitch = 0;
-	}
-
 	return ProxyInterface->LockRect(pLockedRect, pRect, Flags);
 }
 HRESULT STDMETHODCALLTYPE Direct3DSurface8::UnlockRect()

--- a/source/d3d8to9_volume.cpp
+++ b/source/d3d8to9_volume.cpp
@@ -90,14 +90,6 @@ HRESULT STDMETHODCALLTYPE Direct3DVolume8::GetDesc(D3DVOLUME_DESC8 *pDesc)
 }
 HRESULT STDMETHODCALLTYPE Direct3DVolume8::LockBox(D3DLOCKED_BOX *pLockedVolume, const D3DBOX *pBox, DWORD Flags)
 {
-	if (pLockedVolume != nullptr)
-	{
-		// D3D8 clears the contents of pLockedVolume
-		pLockedVolume->pBits = nullptr;
-		pLockedVolume->RowPitch = 0;
-		pLockedVolume->SlicePitch = 0;
-	}
-
 	return ProxyInterface->LockBox(pLockedVolume, pBox, Flags);
 }
 HRESULT STDMETHODCALLTYPE Direct3DVolume8::UnlockBox()


### PR DESCRIPTION
Reverts #185. I've written a more extensive test to run against both modern d3d9 drivers and Windows XP, and it appears d3d9 already performs the required content clears, so explicitly clearing pLockedRect/Box is quite superfluous. Sorry for the noise.