### PR TITLE
Default to using 0 for MultiSampleQuality

### DIFF
--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -180,21 +180,6 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
-	// Get multisample quality level
-	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
-	{
-		DWORD QualityLevels = 0;
-		if (ProxyInterface->CheckDeviceMultiSampleType(Adapter,
-			DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
-			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
-			ProxyInterface->CheckDeviceMultiSampleType(Adapter,
-				DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
-				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
-		{
-			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
-		}
-	}
-
 	IDirect3DDevice9 *DeviceInterface = nullptr;
 
 	const HRESULT hr = ProxyInterface->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, &PresentParams, &DeviceInterface);

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -169,24 +169,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateAdditionalSwapChain(D3DPRESENT_
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
-	// Get multisample quality level
-	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
-	{
-		DWORD QualityLevels = 0;
-		D3DDEVICE_CREATION_PARAMETERS CreationParams;
-		ProxyInterface->GetCreationParameters(&CreationParams);
-
-		if (D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
-			CreationParams.DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
-			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
-			D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
-				CreationParams.DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
-				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
-		{
-			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
-		}
-	}
-
 	IDirect3DSwapChain9 *SwapChainInterface = nullptr;
 
 	const HRESULT hr = ProxyInterface->CreateAdditionalSwapChain(&PresentParams, &SwapChainInterface);
@@ -210,24 +192,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
-
-	// Get multisample quality level
-	if (PresentParams.MultiSampleType != D3DMULTISAMPLE_NONE)
-	{
-		DWORD QualityLevels = 0;
-		D3DDEVICE_CREATION_PARAMETERS CreationParams;
-		ProxyInterface->GetCreationParameters(&CreationParams);
-
-		if (D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
-			CreationParams.DeviceType, PresentParams.BackBufferFormat, PresentParams.Windowed,
-			PresentParams.MultiSampleType, &QualityLevels) == S_OK &&
-			D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal,
-				CreationParams.DeviceType, PresentParams.AutoDepthStencilFormat, PresentParams.Windowed,
-				PresentParams.MultiSampleType, &QualityLevels) == S_OK)
-		{
-			PresentParams.MultiSampleQuality = (QualityLevels != 0) ? QualityLevels - 1 : 0;
-		}
-	}
 
 	HRESULT hr = ProxyInterface->Reset(&PresentParams);
 
@@ -395,21 +359,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 
 	*ppSurface = nullptr;
 
-	DWORD QualityLevels = 0;
-
-	// Get multisample quality level
-	if (MultiSample != D3DMULTISAMPLE_NONE)
-	{
-		D3DDEVICE_CREATION_PARAMETERS CreationParams;
-		ProxyInterface->GetCreationParameters(&CreationParams);
-
-		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
-		QualityLevels = (QualityLevels != 0) ? QualityLevels - 1 : 0;
-	}
-
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, QualityLevels, Lockable, &SurfaceInterface, nullptr);
+	const HRESULT hr = ProxyInterface->CreateRenderTarget(Width, Height, Format, MultiSample, 0, Lockable, &SurfaceInterface, nullptr);
 	if (FAILED(hr))
 		return hr;
 
@@ -427,21 +379,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width,
 
 	*ppSurface = nullptr;
 
-	DWORD QualityLevels = 0;
-
-	// Get multisample quality level
-	if (MultiSample != D3DMULTISAMPLE_NONE)
-	{
-		D3DDEVICE_CREATION_PARAMETERS CreationParams;
-		ProxyInterface->GetCreationParameters(&CreationParams);
-
-		D3D->GetProxyInterface()->CheckDeviceMultiSampleType(CreationParams.AdapterOrdinal, CreationParams.DeviceType, Format, FALSE, MultiSample, &QualityLevels);
-		QualityLevels = (QualityLevels != 0) ? QualityLevels - 1 : 0;
-	}
-
 	IDirect3DSurface9 *SurfaceInterface = nullptr;
 
-	const HRESULT hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, QualityLevels, ZBufferDiscarding, &SurfaceInterface, nullptr);
+	const HRESULT hr = ProxyInterface->CreateDepthStencilSurface(Width, Height, Format, MultiSample, 0, ZBufferDiscarding, &SurfaceInterface, nullptr);
 	if (FAILED(hr))
 		return hr;
 

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -132,6 +132,7 @@ void ConvertPresentParameters(D3DPRESENT_PARAMETERS8 &Input, D3DPRESENT_PARAMETE
 	Output.BackBufferFormat = Input.BackBufferFormat;
 	Output.BackBufferCount = Input.BackBufferCount;
 	Output.MultiSampleType = Input.MultiSampleType;
+	// MultiSampleQuality is only used in conjunction with D3DMULTISAMPLE_NONMASKABLE, which is not available in D3D8
 	Output.MultiSampleQuality = 0;
 	Output.SwapEffect = Input.SwapEffect;
 	Output.hDeviceWindow = Input.hDeviceWindow;


### PR DESCRIPTION
I'm not entirely sure why the existing logic was set up in the first place.

The MultiSampleQuality parameter in D3D9 is only intended for use with `D3DMULTISAMPLE_NONMASKABLE`, which is not available in D3D8.

This is implied by the official documentation as well:

> D3DMULTISAMPLE_NONMASKABLE
>     Enables the multisample quality value. See Remarks.

> Whether the display device supports maskable multisampling (more than one sample for a multiple-sample render-target format plus antialias support) or just non-maskable multisampling (only antialias support), the driver for the device provides the number of quality levels for the D3DMULTISAMPLE_NONMASKABLE multiple-sample type.

Therefore, while the current code doesn't do any harm, it is rather pointlessly issuing redundant queries to D3D9, as with anything other than `D3DMULTISAMPLE_NONMASKABLE`, `CheckDeviceMultiSampleType` will return `1` for the number of quality levels.

I'm linking the WineD3D implementation of `CheckDeviceMultiSampleType` below, but I have no reason to believe native behaves any differently in modern times, nor that it did back in the day:

https://github.com/wine-mirror/wine/blob/3323a7e4474afc3509ba56eab51b76e7887f6450/dlls/wined3d/directx.c#L1925-L1935

On a side-note, `D3DMULTISAMPLE_NONMASKABLE` is not frequently used on D3D9 side either, but the games that do employ it do indeed set a non-zero MultiSampleQuality value, while all the other games that resort to maskable multisamples use 0.

In case anyone wants a reference for `D3DMULTISAMPLE_NONMASKABLE` use in the future, the games I am aware of (9 out of 125 D3D9 titles I've looked into) are:
- Star Wars: Battlefront
- AquaNox 2: Revelation
- Command & Conquer 3: Tiberium Wars
- Dreamfall: The Longest Journey
- El Matador
- Heroes of Might and Magic V
- Machinarium
- Need for Speed: Underground 2
- The Void