### PR TITLE
Additional checks for StateBlock set

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -195,6 +195,9 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 
 	HRESULT hr = ProxyInterface->Reset(&PresentParams);
 
+	// StateBlocks are destroyed during a Reset in D3D9 so need to clear the cache to handle this properly
+	StateBlockTokens.clear();
+
 	if (SUCCEEDED(hr))
 	{
 		// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
@@ -797,7 +800,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::EndStateBlock(DWORD *pToken)
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::ApplyStateBlock(DWORD Token)
 {
-	if (Token == 0)
+	if (Token == 0 || StateBlockTokens.find(Token) == StateBlockTokens.end())
 		return D3DERR_INVALIDCALL;
 
 	if (IsRecordingState)
@@ -807,7 +810,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::ApplyStateBlock(DWORD Token)
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::CaptureStateBlock(DWORD Token)
 {
-	if (Token == 0)
+	if (Token == 0 || StateBlockTokens.find(Token) == StateBlockTokens.end())
 		return D3DERR_INVALIDCALL;
 
 	if (IsRecordingState)
@@ -817,7 +820,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CaptureStateBlock(DWORD Token)
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::DeleteStateBlock(DWORD Token)
 {
-	if (Token == 0)
+	if (Token == 0 || StateBlockTokens.find(Token) == StateBlockTokens.end())
 		return D3DERR_INVALIDCALL;
 
 	if (IsRecordingState)

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -188,15 +188,19 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 	if (pPresentationParameters == nullptr)
 		return D3DERR_INVALIDCALL;
 
+	// StateBlocks are destroyed during a Reset in D3D9 so need to clear the cache to handle this properly
+	while (!StateBlockTokens.empty())
+	{
+		DWORD Token = *StateBlockTokens.begin();
+		DeleteStateBlock(Token);
+	}
+
 	pCurrentRenderTarget = nullptr;
 
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
 	HRESULT hr = ProxyInterface->Reset(&PresentParams);
-
-	// StateBlocks are destroyed during a Reset in D3D9 so need to clear the cache to handle this properly
-	StateBlockTokens.clear();
 
 	if (SUCCEEDED(hr))
 	{


### PR DESCRIPTION
This pull request does two things:

1. It clears the StateBlock cache on Reset() because the interfaces are no longer available after a Reset.
2. It checks the StateBlock cache to validate the handle before accessing, to prevent a crash in case a game sends in an invalid or released handle.