### PR TITLE
Check interface address cache on creation

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -175,7 +175,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateAdditionalSwapChain(D3DPRESENT_
 	if (FAILED(hr))
 		return hr;
 
-	*ppSwapChain = new Direct3DSwapChain8(this, SwapChainInterface);
+	*ppSwapChain = ProxyAddressLookupTable->FindAddress<Direct3DSwapChain8>(SwapChainInterface);
 
 	return D3D_OK;
 }
@@ -271,7 +271,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateTexture(UINT Width, UINT Height
 	if (FAILED(hr))
 		return hr;
 
-	*ppTexture = new Direct3DTexture8(this, TextureInterface);
+	*ppTexture = ProxyAddressLookupTable->FindAddress<Direct3DTexture8>(TextureInterface);
 
 	return D3D_OK;
 }
@@ -291,7 +291,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVolumeTexture(UINT Width, UINT 
 	if (FAILED(hr))
 		return hr;
 
-	*ppVolumeTexture = new Direct3DVolumeTexture8(this, TextureInterface);
+	*ppVolumeTexture = ProxyAddressLookupTable->FindAddress<Direct3DVolumeTexture8>(TextureInterface);
 
 	return D3D_OK;
 }
@@ -311,7 +311,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateCubeTexture(UINT EdgeLength, UI
 	if (FAILED(hr))
 		return hr;
 
-	*ppCubeTexture = new Direct3DCubeTexture8(this, TextureInterface);
+	*ppCubeTexture = ProxyAddressLookupTable->FindAddress<Direct3DCubeTexture8>(TextureInterface);
 
 	return D3D_OK;
 }
@@ -328,7 +328,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateVertexBuffer(UINT Length, DWORD
 	if (FAILED(hr))
 		return hr;
 
-	*ppVertexBuffer = new Direct3DVertexBuffer8(this, BufferInterface);
+	*ppVertexBuffer = ProxyAddressLookupTable->FindAddress<Direct3DVertexBuffer8>(BufferInterface);
 
 	return D3D_OK;
 }
@@ -345,7 +345,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateIndexBuffer(UINT Length, DWORD 
 	if (FAILED(hr))
 		return hr;
 
-	*ppIndexBuffer = new Direct3DIndexBuffer8(this, BufferInterface);
+	*ppIndexBuffer = ProxyAddressLookupTable->FindAddress<Direct3DIndexBuffer8>(BufferInterface);
 
 	return D3D_OK;
 }
@@ -365,7 +365,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateRenderTarget(UINT Width, UINT H
 	if (FAILED(hr))
 		return hr;
 
-	*ppSurface = new Direct3DSurface8(this, SurfaceInterface);
+	*ppSurface = ProxyAddressLookupTable->FindAddress<Direct3DSurface8>(SurfaceInterface);
 
 	return D3D_OK;
 }
@@ -385,7 +385,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateDepthStencilSurface(UINT Width,
 	if (FAILED(hr))
 		return hr;
 
-	*ppSurface = new Direct3DSurface8(this, SurfaceInterface);
+	*ppSurface = ProxyAddressLookupTable->FindAddress<Direct3DSurface8>(SurfaceInterface);
 
 	return D3D_OK;
 }
@@ -417,7 +417,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::CreateImageSurface(UINT Width, UINT H
 		return hr;
 	}
 
-	*ppSurface = new Direct3DSurface8(this, SurfaceInterface);
+	*ppSurface = ProxyAddressLookupTable->FindAddress<Direct3DSurface8>(SurfaceInterface);
 
 	return D3D_OK;
 }


### PR DESCRIPTION
This pull request replaces the "new" call to create an interface class with the `FindAddress` call.  This way it can use an existing interface that has the same ProxyInterface address (if it exists) instead of creating a new one.

Currently, d3d8to9 will only delete interface classes when the root device is released.  If a game creates new interfaces all the time (like StateBlocks or Textures) it could use a lot of memory before the device is released.  This update might help in some cases where the device creates interfaces with the same address as a previous interface (of the same type) to attempt to reduce the memory usage.