### PR TITLE
Fix DebugSetMute log message

### DIFF
--- a/source/d3d8to9.cpp
+++ b/source/d3d8to9.cpp
@@ -125,7 +125,7 @@ extern "C" HRESULT WINAPI ValidateVertexShader(const DWORD* pVertexShader, const
 extern "C" void WINAPI DebugSetMute()
 {
 #ifndef D3D8TO9NOLOG
-	LOG << "Redirecting '" << "DebugSetMute ()" << "'..." << std::endl;
+	LOG << "Redirecting '" << "DebugSetMute" << "(" << ")' ..." << std::endl;
 #endif
 }
 


### PR DESCRIPTION
Just noticed this isn't getting printed in the usual/expected format vs the other loggers. Not sure where I was going with this originally, but it probably got copy-pasted and missed before pushing.