### PR TITLE
Release state blocks on Reset if the device has been lost

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -190,10 +190,20 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 
 	pCurrentRenderTarget = nullptr;
 
+	const HRESULT deviceState = ProxyInterface->TestCooperativeLevel();
+
+	if (deviceState == D3DERR_DEVICENOTRESET) {
+		while (!StateBlockTokens.empty())
+		{
+			DWORD Token = *StateBlockTokens.begin();
+			DeleteStateBlock(Token);
+		}
+	}
+
 	D3DPRESENT_PARAMETERS PresentParams;
 	ConvertPresentParameters(*pPresentationParameters, PresentParams);
 
-	HRESULT hr = ProxyInterface->Reset(&PresentParams);
+	const HRESULT hr = ProxyInterface->Reset(&PresentParams);
 
 	if (SUCCEEDED(hr))
 	{


### PR DESCRIPTION
@elishacloud Looks like you were onto something with #200, but I suggest we limit its scope a bit for the reasons I've explained in that PR.

Regarding #189, the problem with the game crashing after a return from the "Options" window pop-up is because the game relies on device lost behavior, as I suspected. However, that is actually signaled properly by d3d9, but the reset fails because the game doesn't delete its previously created state blocks before that happens.

The solution below isn't entirely ideal either, however in such cases it makes sense because the application has no alternative but to call Reset (most common) or release and recreate another device once its current device becomes lost, and if it can't do that, well... it will crash or hang, as observed with A.I.M.

As to the handling I've done below, excerpt from the docs: 

> If an application detects a lost device, it should pause and periodically call IDirect3DDevice9::TestCooperativeLevel until it receives a return value of D3DERR_DEVICENOTRESET. The application may then attempt to reset the device by calling [IDirect3DDevice9::Reset](https://learn.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-idirect3ddevice9-reset) and, if this succeeds, restore the necessary resources and resume normal operation.

This change is enough to get things working properly in A.I.M. at least, with no ill side effects. I suspect it might also help in other situations when games crash or get stuck while alt+tab-ing or have a regular flow in which the main game window loses focus. To be a bit more robust in handling these cases, I suggest #203 gets merged before this PR, because then at least we would not crash if a game attempts to reuse (post-reset) a token for a state block we were forced to release.