### PR TITLE
Rayman 3: Protect against Use-After-Release in DeleteVertexShader() and DeletePixelShader()

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -1639,11 +1639,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::DeleteVertexShader(DWORD Handle)
 	if ((Handle & 0x80000000) == 0)
 		return D3DERR_INVALIDCALL;
 
-	auto it = VertexShaderHandles.find(Handle);
-	if (it == VertexShaderHandles.end())
-		return D3D_OK;
-
-	VertexShaderHandles.erase(it);
+	if (VertexShaderHandles.erase(Handle) == 0)
+		return D3DERR_INVALIDCALL;
 
 	if (CurrentVertexShaderHandle == Handle)
 	{
@@ -2249,11 +2246,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::DeletePixelShader(DWORD Handle)
 	if (Handle == 0)
 		return D3DERR_INVALIDCALL;
 
-	auto it = PixelShaderHandles.find(Handle);
-	if (it == PixelShaderHandles.end())
-		return D3D_OK;
-
-	PixelShaderHandles.erase(it);
+	if (PixelShaderHandles.erase(Handle) == 0)
+		return D3DERR_INVALIDCALL;
 
 	if (CurrentPixelShaderHandle == Handle)
 		SetPixelShader(0);


### PR DESCRIPTION
This PR resolves a crash in Rayman 3 that occurs sometimes during loading screens. The issue was traced to the `IDirect3DDevice::DeleteVertexShader(0x17369F8C)` function, specifically within the following code:

```cpp
const DWORD HandleMagic = Handle << 1;
VertexShaderInfo *const ShaderInfo = reinterpret_cast<VertexShaderInfo *>(HandleMagic);

if (ShaderInfo->Shader != nullptr) 
{
    ShaderInfo->Shader->Release(); // crashed here
    VertexShaderAndDeclarationCount--;
}
```

The crash happened because `ShaderInfo->Shader` was not `nullptr`, but its vtable pointer had already been nulled out. This probably means that the game called `DeleteVertexShader()` twice on the shader.

I managed to solve this issue by checking if the handle is still part of `VertexShaderHandles`. If not,  <del>`D3D_ERRINVALIDCALL `</del> `D3D_OK` is returned, and no additional `Release()`-calls are executed. This change was applied to both `DeleteVertexShader()` and `DeleteVertexShader()`.

This issue is similar to the one addressed in PR #203. Like described in https://github.com/crosire/d3d8to9/pull/200#issuecomment-3042800958, I changed the returned Value to `D3D_OK`.