### PR TITLE
Better handling of ZBias to DepthBias computing

### DIFF
--- a/source/d3d8to9.hpp
+++ b/source/d3d8to9.hpp
@@ -53,7 +53,7 @@ class Direct3DDevice8 : public IDirect3DDevice8
 	Direct3DDevice8 &operator=(const Direct3DDevice8 &) = delete;
 
 public:
-	Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, DWORD BehaviorFlags, BOOL EnableZBufferDiscarding = FALSE);
+	Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, DWORD BehaviorFlags, D3DFORMAT ZBufferFormat, BOOL EnableZBufferDiscarding);
 	~Direct3DDevice8();
 
 	IDirect3DDevice9 *GetProxyInterface() const { return ProxyInterface; }
@@ -165,8 +165,10 @@ private:
 
 	Direct3D8 *const D3D;
 	IDirect3DDevice9 *const ProxyInterface;
-	INT CurrentBaseVertexIndex = 0;
 	const BOOL ZBufferDiscarding = FALSE;
+	DWORD ZBufferBitCount = 0;
+	DWORD ZBiasRenderState = 0;
+	INT CurrentBaseVertexIndex = 0;
 	DWORD CurrentVertexShaderHandle = 0, CurrentPixelShaderHandle = 0;
 	IDirect3DSurface9 *pCurrentRenderTarget = nullptr;
 	bool PaletteFlag = false;

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -186,7 +186,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	if (FAILED(hr))
 		return hr;
 
-	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, BehaviorFlags, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
+	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, BehaviorFlags, PresentParams.AutoDepthStencilFormat ? PresentParams.AutoDepthStencilFormat : D3DFMT_UNKNOWN, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	// Set default vertex declaration
 	DeviceInterface->SetFVF(D3DFVF_XYZ);

--- a/source/d3d8to9_base.cpp
+++ b/source/d3d8to9_base.cpp
@@ -186,7 +186,7 @@ HRESULT STDMETHODCALLTYPE Direct3D8::CreateDevice(UINT Adapter, D3DDEVTYPE Devic
 	if (FAILED(hr))
 		return hr;
 
-	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, BehaviorFlags, PresentParams.AutoDepthStencilFormat ? PresentParams.AutoDepthStencilFormat : D3DFMT_UNKNOWN, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
+	*ppReturnedDeviceInterface = new Direct3DDevice8(this, DeviceInterface, BehaviorFlags, PresentParams.EnableAutoDepthStencil ? PresentParams.AutoDepthStencilFormat : D3DFMT_UNKNOWN, (PresentParams.Flags & D3DPRESENTFLAG_DISCARD_DEPTHSTENCIL) != 0);
 
 	// Set default vertex declaration
 	DeviceInterface->SetFVF(D3DFVF_XYZ);

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -573,13 +573,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(IDirect3DSurface8 *pR
 		if (FAILED(hr))
 			return hr;
 
-		if (ZBiasRenderState != 0)
-		{
-			D3DSURFACE_DESC8 Desc = {};
-			pNewZStencilImpl->GetDesc(&Desc);
-			ZBufferBitCount = GetDepthStencilBitCount(Desc.Format);
-			ProxyInterface->SetRenderState(D3DRS_DEPTHBIAS, CalcDepthBias(ZBiasRenderState, ZBufferBitCount));
-		}
+		D3DSURFACE_DESC8 Desc = {};
+		pNewZStencilImpl->GetDesc(&Desc);
+		ZBufferBitCount = GetDepthStencilBitCount(Desc.Format);
+		ProxyInterface->SetRenderState(D3DRS_DEPTHBIAS, CalcDepthBias(ZBiasRenderState, ZBufferBitCount));
 	}
 	else
 	{

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -190,6 +190,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 	if (pPresentationParameters == nullptr)
 		return D3DERR_INVALIDCALL;
 
+	ZBiasRenderState = 0;
+
 	pCurrentRenderTarget = nullptr;
 
 	D3DPRESENT_PARAMETERS PresentParams;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -14,11 +14,13 @@ struct VertexShaderInfo
 	IDirect3DVertexDeclaration9 *Declaration = nullptr;
 };
 
-Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, DWORD BehaviorFlags, BOOL EnableZBufferDiscarding) :
+Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterface, DWORD BehaviorFlags, D3DFORMAT ZBufferFormat, BOOL EnableZBufferDiscarding) :
 	D3D(d3d), ProxyInterface(ProxyInterface), ZBufferDiscarding(EnableZBufferDiscarding)
 {
 	ProxyAddressLookupTable = new AddressLookupTable(this);
 	PaletteFlag = SupportsPalettes();
+
+	ZBufferBitCount = GetDepthStencilBitCount(ZBufferFormat);
 
 	IsMixedVPModeDevice = BehaviorFlags & D3DCREATE_MIXED_VERTEXPROCESSING;
 	// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
@@ -568,6 +570,14 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderTarget(IDirect3DSurface8 *pR
 		hr = ProxyInterface->SetDepthStencilSurface(pNewZStencilImpl->GetProxyInterface());
 		if (FAILED(hr))
 			return hr;
+
+		if (ZBiasRenderState != 0)
+		{
+			D3DSURFACE_DESC8 Desc = {};
+			pNewZStencilImpl->GetDesc(&Desc);
+			ZBufferBitCount = GetDepthStencilBitCount(Desc.Format);
+			ProxyInterface->SetRenderState(D3DRS_DEPTHBIAS, CalcDepthBias(ZBiasRenderState, ZBufferBitCount));
+		}
 	}
 	else
 	{
@@ -705,7 +715,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetClipPlane(DWORD Index, float *pPla
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value)
 {
-	FLOAT Biased;
 	HRESULT hr;
 
 	switch (static_cast<DWORD>(State))
@@ -728,8 +737,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::SetRenderState(D3DRENDERSTATETYPE Sta
 			ClipPlaneRenderState = Value;
 		return hr;
 	case D3DRS_ZBIAS:
-		Biased = static_cast<FLOAT>(Value) * -0.000005f;
-		Value = *reinterpret_cast<const DWORD *>(&Biased);
+		ZBiasRenderState = Value;
+		Value = CalcDepthBias(Value, ZBufferBitCount);
 		State = D3DRS_DEPTHBIAS;
 	default:
 		return ProxyInterface->SetRenderState(State, Value);
@@ -740,7 +749,6 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderState(D3DRENDERSTATETYPE Sta
 	if (pValue == nullptr)
 		return D3DERR_INVALIDCALL;
 
-	HRESULT hr;
 	*pValue = 0;
 
 	switch (static_cast<DWORD>(State))
@@ -752,9 +760,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetRenderState(D3DRENDERSTATETYPE Sta
 	case D3DRS_EDGEANTIALIAS:
 		return ProxyInterface->GetRenderState(D3DRS_ANTIALIASEDLINEENABLE, pValue);
 	case D3DRS_ZBIAS:
-		hr = ProxyInterface->GetRenderState(D3DRS_DEPTHBIAS, pValue);
-		*pValue = static_cast<DWORD>(*reinterpret_cast<const FLOAT*>(pValue) * -200000.0f);
-		return hr;
+		*pValue = ZBiasRenderState;
+		return D3D_OK;
 	case D3DRS_SOFTWAREVERTEXPROCESSING:
 		*pValue = static_cast<DWORD>(ProxyInterface->GetSoftwareVertexProcessing());
 		return D3D_OK;

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -50,7 +50,7 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 		return 0;
 
 	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 32UL) : 16;
-	float DepthBias = -static_cast<float>(std::min<double>(ZBias, 16) / ((1ULL << DepthBitCount) - 1));
+	float DepthBias = -(std::min<float>(ZBias, 16) / ((1ULL << DepthBitCount) - 1));
 	return *reinterpret_cast<DWORD*>(&DepthBias);
 }
 

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -49,8 +49,8 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 	if (ZBias == 0)
 		return 0;
 
-	DepthBitCount = DepthBitCount ? DepthBitCount : 16;
-	float DepthBias = static_cast<float>(static_cast<double>(std::min(ZBias, 16UL)) * (1.0 / ((1ULL << std::min(std::max(DepthBitCount, 15UL), 32UL)) - 1)));
+	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 32UL) : 16;
+	float DepthBias = -static_cast<float>(std::min<double>(ZBias, 16) / ((1ULL << DepthBitCount) - 1));
 	return *reinterpret_cast<DWORD*>(&DepthBias);
 }
 

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -51,7 +51,7 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 
 	// 24-bits of precision is the max handled by a float
 	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 24UL) : 16;
-	float DepthBias = -(std::min<float>(ZBias, 16) / ((1ULL << DepthBitCount) - 1));
+	float DepthBias = -(static_cast<float>(std::min(ZBias, 16UL)) / ((1ULL << DepthBitCount) - 1));
 	return *reinterpret_cast<DWORD*>(&DepthBias);
 }
 

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -49,7 +49,8 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 	if (ZBias == 0)
 		return 0;
 
-	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 32UL) : 16;
+	// 24-bits of precision is the max handled by a float
+	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 24UL) : 16;
 	float DepthBias = -(std::min<float>(ZBias, 16) / ((1ULL << DepthBitCount) - 1));
 	return *reinterpret_cast<DWORD*>(&DepthBias);
 }

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -25,6 +25,35 @@ bool IsDepthStencil(D3DFORMAT &Format) {
 		|| Format == D3DFMT_D24X8;
 }
 
+DWORD GetDepthStencilBitCount(D3DFORMAT Format)
+{
+	switch (Format)
+	{
+	case D3DFMT_D15S1:
+		return 15;
+	case D3DFMT_D16_LOCKABLE:
+	case D3DFMT_D16:
+		return 16;
+	case D3DFMT_D24X4S4:
+	case D3DFMT_D24S8:
+	case D3DFMT_D24X8:
+		return 24;
+	case D3DFMT_D32:
+		return 32;
+	}
+	return 0;
+}
+
+DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
+{
+	if (ZBias == 0)
+		return 0;
+
+	DepthBitCount = DepthBitCount ? DepthBitCount : 16;
+	float DepthBias = static_cast<float>(static_cast<double>(std::min(ZBias, 16UL)) * (1.0 / ((1ULL << std::min(std::max(DepthBitCount, 15UL), 32UL)) - 1)));
+	return *reinterpret_cast<DWORD*>(&DepthBias);
+}
+
 static UINT CalcTextureSize(UINT Width, UINT Height, UINT Depth, D3DFORMAT Format)
 {
 	switch (static_cast<DWORD>(Format))

--- a/source/d3d8types.hpp
+++ b/source/d3d8types.hpp
@@ -194,6 +194,9 @@ struct D3DADAPTER_IDENTIFIER8
 bool SupportsPalettes();
 bool IsDepthStencil(D3DFORMAT &format);
 
+DWORD GetDepthStencilBitCount(D3DFORMAT Format);
+DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBits);
+
 void ConvertCaps(D3DCAPS9 &input, D3DCAPS8 &output);
 void ConvertVolumeDesc(D3DVOLUME_DESC &input, D3DVOLUME_DESC8 &output);
 void ConvertSurfaceDesc(D3DSURFACE_DESC &input, D3DSURFACE_DESC8 &output);


### PR DESCRIPTION
This pull request updates the conversion from ZBias to DepthBias, taking into account the actual depth buffer bit count in use.

This ensures a more accurate and consistent translation between the two bias systems.

Additionally, it guarantees that `GetRenderState(D3DRS_ZBIAS)` now always returns the correct corresponding value.