### PR TITLE
Fix epsilon value for DepthBias

### DIFF
--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -28,8 +28,8 @@ Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterfac
 	ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
 	// The DEPTHBIAS value of -0.0f works differently than 0.0f
 	// Some games require defaulting to -0.0f to work correctly
-	float Value = -0.0f;
-	ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, *(DWORD*)&Value);
+	float DepthBias = -0.0f;
+	ProxyInterface->SetRenderState(D3DRS_DEPTHBIAS, *(DWORD*)&DepthBias);
 }
 Direct3DDevice8::~Direct3DDevice8()
 {
@@ -218,8 +218,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 		ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
 		// The DEPTHBIAS value of -0.0f works differently than 0.0f
 		// Some games require defaulting to -0.0f to work correctly
-		float Value = -0.0f;
-		ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, *(DWORD*)&Value);
+		float DepthBias = -0.0f;
+		ProxyInterface->SetRenderState(D3DRS_DEPTHBIAS, *(DWORD*)&DepthBias);
 	}
 
 	return hr;

--- a/source/d3d8to9_device.cpp
+++ b/source/d3d8to9_device.cpp
@@ -26,6 +26,10 @@ Direct3DDevice8::Direct3DDevice8(Direct3D8 *d3d, IDirect3DDevice9 *ProxyInterfac
 	// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
 	// whereas in D3D9 it is 1.0f, so adjust it as needed
 	ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
+	// The DEPTHBIAS value of -0.0f works differently than 0.0f
+	// Some games require defaulting to -0.0f to work correctly
+	float Value = -0.0f;
+	ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, *(DWORD*)&Value);
 }
 Direct3DDevice8::~Direct3DDevice8()
 {
@@ -212,6 +216,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::Reset(D3DPRESENT_PARAMETERS8 *pPresen
 		// The default value of D3DRS_POINTSIZE_MIN is 0.0f in D3D8,
 		// whereas in D3D9 it is 1.0f, so adjust it as needed
 		ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, (DWORD) 0.0f);
+		// The DEPTHBIAS value of -0.0f works differently than 0.0f
+		// Some games require defaulting to -0.0f to work correctly
+		float Value = -0.0f;
+		ProxyInterface->SetRenderState(D3DRS_POINTSIZE_MIN, *(DWORD*)&Value);
 	}
 
 	return hr;

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -46,12 +46,22 @@ DWORD GetDepthStencilBitCount(D3DFORMAT Format)
 
 DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 {
-	if (ZBias == 0)
-		return 0;
-
-	// 24-bits of precision is the max handled by a float
-	DepthBitCount = DepthBitCount ? std::min(std::max(DepthBitCount, 15UL), 24UL) : 16;
-	float DepthBias = -(static_cast<float>(std::min(ZBias, 16UL)) / ((1ULL << DepthBitCount) - 1));
+	float DepthEpsilon;
+	switch (DepthBitCount)
+	{
+	case 32:
+	case 24:
+		DepthEpsilon = -0.00014f;
+		break;
+	default:
+	case 16:
+		DepthEpsilon = -0.00028f;
+		break;
+	case 15:
+		DepthEpsilon = -0.00035f;
+		break;
+	}
+	float DepthBias = std::min(ZBias, 16UL) * DepthEpsilon;
 	return *reinterpret_cast<DWORD*>(&DepthBias);
 }
 

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -51,14 +51,14 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 	{
 	case 32:
 	case 24:
-		DepthEpsilon = -0.00014f;
+		DepthEpsilon = -10.0f / (1 << 16);
 		break;
 	default:
 	case 16:
-		DepthEpsilon = -0.00028f;
+		DepthEpsilon = -20.0f / (1 << 16);
 		break;
 	case 15:
-		DepthEpsilon = -0.00035f;
+		DepthEpsilon = -25.0f / (1 << 16);
 		break;
 	}
 	float DepthBias = std::min(ZBias, 16UL) * DepthEpsilon;


### PR DESCRIPTION
This fixes PR #209.  It also fixes [dxwrapper/#268](https://github.com/elishacloud/dxwrapper/issues/268)

There were two issues with the previous PR:

1. The previous PR would return 0.0f for DepthBias rather than -0.0f.

The default DepthBias is 0.0f and the default ZBias is 0.  The original code (before either PR) would multiple ZBias times -0.000005.  If ZBias was 0 then it would set DepthBias to -0.0f.  So, if a game doesn't set ZBias then DepthBias would be 0.0f.  However, if the game sets ZBias to 0 (the default) then it would actually set DepthBias to -0.0f, which is inconsistent.  Meaning, the default DepthBias would change from 0.0f to -0.0f depending on whether the game set ZBias or not.

My previous PR fixed this by forcing the DepthBias to always be 0.0f whenever a game set Zbias to 0.  However, this broke at least one game (Freelancer).  Apparently, Direct3D9 treats 0.0f and -0.0f differently.  So now this will always set DepthBias to -0.0f and sets the default state to -0.0f to keep it consistent.

2. Sets the correct epsilon number for DepthBias.

In my last PR I had the understanding that the smaller the epsilon for DepthBias, the better.  However, this didn't hold true for a number of games.  The fact is that d3d8 has a larger effect on the z-level than I understood.  With this update I did a bunch of tests to try and make DepthBias work as close to d3d8's ZBias as I could.  This update should be much closer to d3d8 than -0.000005 or than the tiny numbers I used in the last PR were.