### PR TITLE
Use smallest epsilon number for DepthBias

### DIFF
--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -51,7 +51,8 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 	{
 	case 32:
 	case 24:
-		DepthEpsilon = -FLT_EPSILON;
+		// Bit shifting by 24 is too small for float precision. A shift of 20 seems to work best.
+		DepthEpsilon = -1.0f / ((1 << 20) - 1);
 		break;
 	default:
 	case 16:

--- a/source/d3d8types.cpp
+++ b/source/d3d8types.cpp
@@ -51,14 +51,14 @@ DWORD CalcDepthBias(DWORD ZBias, DWORD DepthBitCount)
 	{
 	case 32:
 	case 24:
-		DepthEpsilon = -10.0f / (1 << 16);
+		DepthEpsilon = -FLT_EPSILON;
 		break;
 	default:
 	case 16:
-		DepthEpsilon = -20.0f / (1 << 16);
+		DepthEpsilon = -1.0f / ((1 << 16) - 1);
 		break;
 	case 15:
-		DepthEpsilon = -25.0f / (1 << 16);
+		DepthEpsilon = -1.0f / ((1 << 15) - 1);
 		break;
 	}
 	float DepthBias = std::min(ZBias, 16UL) * DepthEpsilon;


### PR DESCRIPTION
Sorry for the third PR on this issue!  I believe this should be the last one.

This pull request is based on the comments in PR #209.  I have tested with several games, including:  Arx Fatalis, Freelancer, Silent Hill 2.  There is no single value for the DepthBias that will work perfectly for all games.

In DX8 and older there are only 17 bias levels (0 to 16).  But there is no generic way to convert them to DX9's DepthBias.  Some games (like Freelancer) require larger DepthBias to avoid incorrect z-ordering, while other games (like Arx Fatalis and Silent Hill 2) require smaller DepthBias.

I think the best solution is use the lowest epsilon value for each buffer and then create an option for multiplying this by some other value as needed.

This PR will set it to a low epsilon value.  Then I will add an option to dxwrapper to allow it to be customized beyond that.  Since we want this d3d8to9 to work without options, I think this is the best solution for d3d8to9.